### PR TITLE
Do the journal templating in Python again

### DIFF
--- a/fava/api/serialization.py
+++ b/fava/api/serialization.py
@@ -28,7 +28,7 @@ class BeanJSONEncoder(JSONEncoder):
 
 transaction_types = {
     '*': 'cleared',
-    '!': 'uncleared',
+    '!': 'pending',
     'P': 'padding',
     'S': 'summarize',
     'T': 'transfer',
@@ -56,12 +56,14 @@ def serialize_entry(entry):
             new_entry['balance'] = entry.diff_amount + entry.amount
 
     if isinstance(entry, Transaction):
-        new_entry['transaction_type'] = transaction_types[entry.flag]
+        if entry.flag in transaction_types:
+            new_entry['transaction_type'] = transaction_types[entry.flag]
+        else:
+            new_entry['transaction_type'] = 'other'
 
-        new_entry.pop('entrys', None)
         new_entry['tags'] = entry.tags or []
         new_entry['links'] = entry.links or []
-        new_entry['legs'] = [serialize_posting(p) for p in entry.postings]
+        new_entry['postings'] = [serialize_posting(p) for p in entry.postings]
 
     return new_entry
 

--- a/fava/application.py
+++ b/fava/application.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime
 
 from flask import Flask, flash, render_template, url_for, request, redirect,\
-                  send_from_directory, jsonify, g
+                  send_from_directory, g
 
 from fava.api import BeancountReportAPI, FilterException
 from fava.api.serialization import BeanJSONEncoder
@@ -106,12 +106,7 @@ def get_stored_query(stored_query_hash=None):
 
 @app.route('/journal/')
 def journal():
-    if request.is_xhr:
-        return jsonify({
-            'data': app.api.journal(with_change_and_balance=app.config.user.getboolean('journal-general-show-balances'))
-        })
-    else:
-        return render_template('journal.html')
+    return render_template('journal.html')
 
 
 @app.route('/source/', methods=['GET', 'POST'])

--- a/fava/default-settings.conf
+++ b/fava/default-settings.conf
@@ -22,10 +22,11 @@ journal-show-type-pad = False
 journal-show-type-query = False
 
 journal-show-transaction-cleared = True
-journal-show-transaction-uncleared = True
+journal-show-transaction-pending = True
 journal-show-transaction-padding = False
 journal-show-transaction-summarize = False
 journal-show-transaction-transfer = False
+journal-show-transaction-other = True
 
 ; If True changes and balances will be shown in the General Journal view
 journal-general-show-balances = False

--- a/fava/default-settings.conf
+++ b/fava/default-settings.conf
@@ -19,8 +19,13 @@ journal-show-type-balance = True
 journal-show-type-note = True
 journal-show-type-document = True
 journal-show-type-pad = False
-journal-show-type-padding = False
 journal-show-type-query = False
+
+journal-show-transaction-cleared = True
+journal-show-transaction-uncleared = True
+journal-show-transaction-padding = False
+journal-show-transaction-summarize = False
+journal-show-transaction-transfer = False
 
 ; If True changes and balances will be shown in the General Journal view
 journal-general-show-balances = False

--- a/fava/static/javascript/journal.js
+++ b/fava/static/javascript/journal.js
@@ -3,7 +3,7 @@ function initJournal() {
     $('table.journal-table tr[data-type="transaction"]').click(function() {
         var $this = $(this);
         var hash = $this.attr('data-hash');
-        $('table.journal-table tr[data-parent-hash="' + hash + '"]').toggle();
+        $('table.journal-table tr[data-parent-hash="' + hash + '"]').toggleClass("hidden");
     });
     initJournalFilters();
 }

--- a/fava/static/javascript/journal.js
+++ b/fava/static/javascript/journal.js
@@ -1,9 +1,9 @@
 function initJournal() {
     // Toggle legs by clicking on transaction/padding row
-    $('table.journal-table tr[data-type="transaction"]').click(function() {
+    $('#journal-table tr[data-type="transaction"]').click(function() {
         var $this = $(this);
         var hash = $this.attr('data-hash');
-        $('table.journal-table tr[data-parent-hash="' + hash + '"]').toggleClass("hidden");
+        $('#journal-table tr[data-parent-hash="' + hash + '"]').toggleClass("hidden");
     });
     initJournalFilters();
 }
@@ -15,11 +15,11 @@ function initJournalFilters() {
         var type = $this.attr('data-type');
         var shouldShow = $this.prop('checked');
         if (shouldShow) {
-            $('table.journal-table tr[data-type="' + type + '"]').removeClass('hidden');
-            $('table.journal-table tr.posting-' + type + '').removeClass('hidden-parent');
+            $('#journal-table tr[data-type="' + type + '"]').removeClass('hidden');
+            $('#journal-table tr.posting-' + type + '').removeClass('hidden-parent');
         } else {
-            $('table.journal-table tr[data-type="' + type + '"]').addClass('hidden');
-            $('table.journal-table tr.posting-' + type + '').addClass('hidden-parent');
+            $('#journal-table tr[data-type="' + type + '"]').addClass('hidden');
+            $('#journal-table tr.posting-' + type + '').addClass('hidden-parent');
         }
     });
 
@@ -29,11 +29,11 @@ function initJournalFilters() {
         var type = $this.attr('data-type');
         var shouldShow = $this.prop('checked');
         if (shouldShow) {
-            $('table.journal-table tr.' + type).removeClass('hidden-type');
-            $('table.journal-table tr.posting-' + type + '').removeClass('hidden-parent-type');
+            $('#journal-table tr.' + type).removeClass('hidden-type');
+            $('#journal-table tr.posting-' + type + '').removeClass('hidden-parent-type');
         } else {
-            $('table.journal-table tr.' + type).addClass('hidden-type');
-            $('table.journal-table tr.posting-' + type + '').addClass('hidden-parent-type');
+            $('#journal-table tr.' + type).addClass('hidden-type');
+            $('#journal-table tr.posting-' + type + '').addClass('hidden-parent-type');
         }
     });
 
@@ -42,9 +42,9 @@ function initJournalFilters() {
         event.preventDefault();
         var shouldShow = ($(this).val() == 'Show legs');
         if (shouldShow) {
-            $('table.journal-table tr[data-type="posting"]').removeClass('hidden');
+            $('#journal-table tr[data-type="posting"]').removeClass('hidden');
         } else {
-            $('table.journal-table tr[data-type="posting"]').addClass('hidden');
+            $('#journal-table tr[data-type="posting"]').addClass('hidden');
         }
         $(this).val(shouldShow ? 'Hide legs' : 'Show legs');
     });
@@ -54,9 +54,9 @@ function initJournalFilters() {
         event.preventDefault();
         var shouldShow = ($(this).val() == 'Show metadata');
         if (shouldShow) {
-            $('table.journal-table dl.metadata').removeClass('hidden');
+            $('#journal-table dl.metadata').removeClass('hidden');
         } else {
-            $('table.journal-table dl.metadata').addClass('hidden');
+            $('#journal-table dl.metadata').addClass('hidden');
         }
         $(this).val(shouldShow ? 'Hide metadata' : 'Show metadata');
     });

--- a/fava/static/javascript/journal.js
+++ b/fava/static/javascript/journal.js
@@ -1,8 +1,7 @@
 function initJournal() {
     // Toggle legs by clicking on transaction/padding row
     $('#journal-table tr[data-type="transaction"]').click(function() {
-        var $this = $(this);
-        var hash = $this.attr('data-hash');
+        var hash = $(this).attr('data-hash');
         $('#journal-table tr[data-parent-hash="' + hash + '"]').toggleClass("hidden");
     });
     initJournalFilters();
@@ -14,13 +13,10 @@ function initJournalFilters() {
         var $this = $(this);
         var type = $this.attr('data-type');
         var shouldShow = $this.prop('checked');
-        if (shouldShow) {
-            $('#journal-table tr[data-type="' + type + '"]').removeClass('hidden');
-            $('#journal-table tr.posting-' + type + '').removeClass('hidden-parent');
-        } else {
-            $('#journal-table tr[data-type="' + type + '"]').addClass('hidden');
-            $('#journal-table tr.posting-' + type + '').addClass('hidden-parent');
-        }
+        $('#journal-table tr[data-type="' + type + '"]').toggleClass('hidden', !shouldShow);
+        if (type == 'transaction') {
+            $('#journal-table tr.posting').toggleClass('hidden-parent', !shouldShow);
+        };
     });
 
     // Toggle transaction types with checkboxes
@@ -28,24 +24,15 @@ function initJournalFilters() {
         var $this = $(this);
         var type = $this.attr('data-type');
         var shouldShow = $this.prop('checked');
-        if (shouldShow) {
-            $('#journal-table tr.' + type).removeClass('hidden-type');
-            $('#journal-table tr.posting-' + type + '').removeClass('hidden-parent-type');
-        } else {
-            $('#journal-table tr.' + type).addClass('hidden-type');
-            $('#journal-table tr.posting-' + type + '').addClass('hidden-parent-type');
-        }
+        $('#journal-table tr.' + type).toggleClass('hidden-type', !shouldShow);
+        $('#journal-table tr.posting-' + type + '').toggleClass('hidden-parent-type', !shouldShow);
     });
 
     // Button "Hide/Show legs"
     $('input#toggle-legs').click(function(event) {
         event.preventDefault();
         var shouldShow = ($(this).val() == 'Show legs');
-        if (shouldShow) {
-            $('#journal-table tr[data-type="posting"]').removeClass('hidden');
-        } else {
-            $('#journal-table tr[data-type="posting"]').addClass('hidden');
-        }
+        $('#journal-table tr[data-type="posting"]').toggleClass('hidden', !shouldShow);
         $(this).val(shouldShow ? 'Hide legs' : 'Show legs');
     });
 
@@ -53,11 +40,7 @@ function initJournalFilters() {
     $('input#toggle-metadata').click(function(event) {
         event.preventDefault();
         var shouldShow = ($(this).val() == 'Show metadata');
-        if (shouldShow) {
-            $('#journal-table dl.metadata').removeClass('hidden');
-        } else {
-            $('#journal-table dl.metadata').addClass('hidden');
-        }
+        $('#journal-table dl.metadata').toggleClass('hidden', !shouldShow);
         $(this).val(shouldShow ? 'Hide metadata' : 'Show metadata');
     });
 }

--- a/fava/static/javascript/journal.js
+++ b/fava/static/javascript/journal.js
@@ -1,110 +1,11 @@
-var Handlebars = require('handlebars');
-
-// http://stackoverflow.com/a/16315366
-Handlebars.registerHelper('ifCond', function (v1, operator, v2, options) {
-    switch (operator) {
-        case '==':
-            return (v1 == v2) ? options.fn(this) : options.inverse(this);
-        case '===':
-            return (v1 === v2) ? options.fn(this) : options.inverse(this);
-        case '<':
-            return (v1 < v2) ? options.fn(this) : options.inverse(this);
-        case '<=':
-            return (v1 <= v2) ? options.fn(this) : options.inverse(this);
-        case '>':
-            return (v1 > v2) ? options.fn(this) : options.inverse(this);
-        case '>=':
-            return (v1 >= v2) ? options.fn(this) : options.inverse(this);
-        case '&&':
-            return (v1 && v2) ? options.fn(this) : options.inverse(this);
-        case '||':
-            return (v1 || v2) ? options.fn(this) : options.inverse(this);
-        default:
-            return options.inverse(this);
-    }
-});
-
-Handlebars.registerHelper('format_currency', function (number) {
-    if (isNumber(number)) return formatCurrency(number);
-});
-
-Handlebars.registerHelper('context_url', function (hash) {
-    return window.contextURL.replace("REPLACEME", hash);
-});
-
-Handlebars.registerHelper('account_url', function (accountName) {
-    return window.accountURL.replace("REPLACEME", accountName);
-});
-
-Handlebars.registerHelper('query_url', function (queryName) {
-    return window.queryURL.replace("REPLACEME", queryName);
-});
-
-Handlebars.registerHelper('tag_url', function (tagName) {
-    return window.tagURL.replace("REPLACEME", tagName);
-});
-
-Handlebars.registerHelper('document_url', function (documentPath) {
-    return window.documentURL.replace("REPLACEME", encodeURIComponent(documentPath));
-});
-
-Handlebars.registerHelper('ifHasElements', function (object, options) {
-    return Object.keys(object).length > 0 ? options.fn(this) : options.inverse(this);
-});
-
-Handlebars.registerHelper('ifShowChangeAndBalance', function (unused, options) {
-    return window.journalShowChangeAndBalance ? options.fn(this) : options.inverse(this);
-});
-
-Handlebars.registerHelper('ifShowLegs', function (unused, options) {
-    return window.journalShowLegs ? options.fn(this) : options.inverse(this);
-});
-
-Handlebars.registerHelper('ifShowMetadata', function (unused, options) {
-    return window.journalShowMetadata ? options.fn(this) : options.inverse(this);
-});
-
-Handlebars.registerHelper('ifShowType', function (unused, options) {
-    return $.inArray(
-            options.data.root.journal[options.data.index].meta.type,
-            window.journalShowTypes
-        ) > -1 ? options.fn(this) : options.inverse(this);
-});
-
-var tableTemplate = Handlebars.compile($("#journal-table-template").html());
-var legTemplate = Handlebars.compile($("#journal-leg-template").html());
-Handlebars.registerPartial('legPartialTemplate', legTemplate)
-
-function drawJournal() {
-    var html = tableTemplate({ journal: window.journalAsJSON });
-    $('.journal-table').html(html);
-
+function initJournal() {
     // Toggle legs by clicking on transaction/padding row
-    $('table.journal-table tr[data-has-legs="True"]').click(function() {
+    $('table.journal-table tr[data-type="transaction"]').click(function() {
         var $this = $(this);
         var hash = $this.attr('data-hash');
-
-        if ($this.hasClass('display-legs')) {
-            $('table.journal-table tr[data-parent-hash="' + hash + '"]').remove();
-        } else {
-            var journalEntry = {};
-            $.each(window.journalAsJSON, function(index, entry) {
-                if (entry.hash == hash) {
-                    journalEntry = entry;
-                    return;
-                }
-            });
-
-            if (journalEntry) {
-                var html = legTemplate({ journalEntry: journalEntry, legs: journalEntry.legs, hash: journalEntry.hash  });
-                $this.after(html);
-            } else {
-                console.warn("Hash not found", hash, window.journalAsJSON);
-            }
-        }
-
-        $this.toggleClass('display-legs');
+        $('table.journal-table tr[data-parent-hash="' + hash + '"]').toggle();
     });
+    initJournalFilters();
 }
 
 function initJournalFilters() {
@@ -113,46 +14,40 @@ function initJournalFilters() {
         var $this = $(this);
         var type = $this.attr('data-type');
         var shouldShow = $this.prop('checked');
-
-        if (shouldShow && $.inArray(type, window.journalShowTypes) == -1) {
-            window.journalShowTypes.push(type);
-        } else if ($.inArray(type, window.journalShowTypes) > -1) {
-            window.journalShowTypes.splice($.inArray(type, window.journalShowTypes), 1);
+        if (shouldShow) {
+            $('table.journal-table tr[data-type="' + type + '"]').removeClass('hidden');
+            $('table.journal-table tr.posting-' + type + '').removeClass('hidden-parent');
+        } else {
+            $('table.journal-table tr[data-type="' + type + '"]').addClass('hidden');
+            $('table.journal-table tr.posting-' + type + '').addClass('hidden-parent');
         }
-
-        drawJournal();
     });
 
     // Button "Hide/Show legs"
     $('input#toggle-legs').click(function(event) {
         event.preventDefault();
-        var shouldShow = !window.journalShowLegs;
-        $('table.journal-table tr[data-type="leg"]:not(.hidden)').toggle(shouldShow).toggleClass('hidden', !shouldShow);
-        window.journalShowLegs = !window.journalShowLegs;
-        drawJournal();
+        var shouldShow = ($(this).val() == 'Show legs');
+        if (shouldShow) {
+            $('table.journal-table tr[data-type="posting"]').removeClass('hidden');
+        } else {
+            $('table.journal-table tr[data-type="posting"]').addClass('hidden');
+        }
         $(this).val(shouldShow ? 'Hide legs' : 'Show legs');
     });
 
     // Button "Hide/Show metadata"
     $('input#toggle-metadata').click(function(event) {
         event.preventDefault();
-        var shouldShow = !window.journalShowMetadata;
-        $('table.journal-table dl.metadata').toggle(shouldShow).toggleClass('hidden', !shouldShow);
-        window.journalShowMetadata = !window.journalShowMetadata;
+        var shouldShow = ($(this).val() == 'Show metadata');
+        if (shouldShow) {
+            $('table.journal-table dl.metadata').removeClass('hidden');
+        } else {
+            $('table.journal-table dl.metadata').addClass('hidden');
+        }
         $(this).val(shouldShow ? 'Hide metadata' : 'Show metadata');
     });
 }
 
 $(document).ready(function() {
-    if (window.journalAsJSON != undefined) {
-        drawJournal();
-        initJournalFilters();
-    } else if (window.journalURL != undefined) {
-        $.get(window.journalURL)
-        .done(function(responseData) {
-            window.journalAsJSON = responseData.data;
-            drawJournal();
-            initJournalFilters();
-        });
-    }
+    initJournal();
 });

--- a/fava/static/javascript/journal.js
+++ b/fava/static/javascript/journal.js
@@ -62,6 +62,4 @@ function initJournalFilters() {
     });
 }
 
-$(document).ready(function() {
-    initJournal();
-});
+module.exports.initJournal = initJournal;

--- a/fava/static/javascript/journal.js
+++ b/fava/static/javascript/journal.js
@@ -9,8 +9,8 @@ function initJournal() {
 }
 
 function initJournalFilters() {
-    // Toggle positions with checkboxes
-    $('.table-filter input[type="checkbox"]').change(function() {
+    // Toggle entries with checkboxes
+    $('#entry-filters input[type="checkbox"]').change(function() {
         var $this = $(this);
         var type = $this.attr('data-type');
         var shouldShow = $this.prop('checked');
@@ -20,6 +20,20 @@ function initJournalFilters() {
         } else {
             $('table.journal-table tr[data-type="' + type + '"]').addClass('hidden');
             $('table.journal-table tr.posting-' + type + '').addClass('hidden-parent');
+        }
+    });
+
+    // Toggle transaction types with checkboxes
+    $('#transaction-filters input[type="checkbox"]').change(function() {
+        var $this = $(this);
+        var type = $this.attr('data-type');
+        var shouldShow = $this.prop('checked');
+        if (shouldShow) {
+            $('table.journal-table tr.' + type).removeClass('hidden-type');
+            $('table.journal-table tr.posting-' + type + '').removeClass('hidden-parent-type');
+        } else {
+            $('table.journal-table tr.' + type).addClass('hidden-type');
+            $('table.journal-table tr.posting-' + type + '').addClass('hidden-parent-type');
         }
     });
 

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -133,42 +133,34 @@ $(document).ready(function() {
     }
 
     // Options in transaction pages:
-    if ($('.table-filter').length) {
+    if ($('#entry-filters').length) {
         Mousetrap.bind({
             'l':   function() { $('#toggle-legs').click(); },
             'm':   function() { $('#toggle-metadata').click(); },
-            's o': function() { $('input#filter-open').click(); },
-            's c': function() { $('input#filter-close').click(); },
-            's t': function() { $('input#filter-transaction').click(); },
-            's b': function() { $('input#filter-balance').click(); },
-            's n': function() { $('input#filter-note').click(); },
-            's d': function() { $('input#filter-document').click(); },
-            's p': function() { $('input#filter-pad').click(); },
-            't c': function() { $('input#filter-cleared').click(); },
-            't u': function() { $('input#filter-uncleared').click(); },
-            't p': function() { $('input#filter-padding').click(); },
-            't s': function() { $('input#filter-summarize').click(); },
-            't t': function() { $('input#filter-transfer').click(); },
+            's o': function() { $('#filter-open').click(); },
+            's c': function() { $('#filter-close').click(); },
+            's t': function() { $('#filter-transaction').click(); },
+            's b': function() { $('#filter-balance').click(); },
+            's n': function() { $('#filter-note').click(); },
+            's d': function() { $('#filter-document').click(); },
+            's p': function() { $('#filter-pad').click(); },
+            't c': function() { $('#filter-cleared').click(); },
+            't u': function() { $('#filter-uncleared').click(); },
+            't p': function() { $('#filter-padding').click(); },
+            't s': function() { $('#filter-summarize').click(); },
+            't t': function() { $('#filter-transfer').click(); },
         }, 'keyup');
     }
 
     Mousetrap.bind({
-        '?': function() { $('.overlay-wrapper').show(); }
+        '?': function() {
+            $('#overlay-wrapper').show();
+            $('#overlay-wrapper, #overlay-wrapper a.close').click(function(e) {
+                e.preventDefault();
+                $('#overlay-wrapper').hide();
+            });
+        },
+        'esc': function() { $('#overlay-wrapper').hide(); }
     }, 'keyup');
 
-    $('.overlay-wrapper, .overlay-wrapper a.close').click(function(e) {
-        if ($(e.target).hasClass('overlay-wrapper') || $(e.target).hasClass('close')) {
-            e.preventDefault();
-            $('.overlay-wrapper').hide();
-        }
-    });
-
-    $('body').keyup(function(e) {
-        if ($('.overlay-wrapper:visible').length && e.which == 27) {
-            $('.overlay-wrapper').hide();
-        }
-    });
 });
-
-
-

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -136,9 +136,7 @@ $(document).ready(function() {
     if ($('.table-filter').length) {
         Mousetrap.bind({
             'l':   function() { $('#toggle-legs').click(); },
-            's l': function() { $('#toggle-legs').click(); },
             'm':   function() { $('#toggle-metadata').click(); },
-            's m': function() { $('#toggle-metadata').click(); },
             's o': function() { $('input#filter-open').click(); },
             's c': function() { $('input#filter-close').click(); },
             's t': function() { $('input#filter-transaction').click(); },
@@ -146,7 +144,11 @@ $(document).ready(function() {
             's n': function() { $('input#filter-note').click(); },
             's d': function() { $('input#filter-document').click(); },
             's p': function() { $('input#filter-pad').click(); },
-            's shift+p': function() { $('input#filter-padding').click(); }
+            't c': function() { $('input#filter-cleared').click(); },
+            't u': function() { $('input#filter-uncleared').click(); },
+            't p': function() { $('input#filter-padding').click(); },
+            't s': function() { $('input#filter-summarize').click(); },
+            't t': function() { $('input#filter-transfer').click(); },
         }, 'keyup');
     }
 

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -77,6 +77,7 @@ $(document).ready(function() {
         Mousetrap.bind({
             'l':   function() { $('#toggle-legs').click(); },
             'm':   function() { $('#toggle-metadata').click(); },
+
             's o': function() { $('#filter-open').click(); },
             's c': function() { $('#filter-close').click(); },
             's t': function() { $('#filter-transaction').click(); },
@@ -84,11 +85,13 @@ $(document).ready(function() {
             's n': function() { $('#filter-note').click(); },
             's d': function() { $('#filter-document').click(); },
             's p': function() { $('#filter-pad').click(); },
+
             't c': function() { $('#filter-cleared').click(); },
-            't u': function() { $('#filter-uncleared').click(); },
-            't p': function() { $('#filter-padding').click(); },
+            't p': function() { $('#filter-pending').click(); },
+            't shift+p': function() { $('#filter-padding').click(); },
             't s': function() { $('#filter-summarize').click(); },
             't t': function() { $('#filter-transfer').click(); },
+            't o': function() { $('#filter-other').click(); },
         }, 'keyup');
     }
 

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -119,14 +119,14 @@ $(document).ready(function() {
     });
 
     // Jumping through charts
-    if ($('.chart-labels').length) {
+    if ($('#chart-labels').length) {
         Mousetrap.bind({
             'shift+c': function() { $('#toggle-chart').click(); },
             'c':       function() {
-                var next = $('.chart-labels label.selected').next();
-                $('.chart-labels label').removeClass('selected');
+                var next = $('#chart-labels label.selected').next();
+                $('#chart-labels label').removeClass('selected');
                 if (next.length) { next.click(); }
-                else             { $('.chart-labels label:first-child').click(); }
+                else             { $('#chart-labels label:first-child').click(); }
             },
 
         }, 'keyup');

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -5,6 +5,8 @@ window.Mousetrap = require('mousetrap');
 require('mousetrap/plugins/bind-dictionary/mousetrap-bind-dictionary');
 
 require('./charts');
+var journal = require('./journal');
+var treeTable = require('./tree-table');
 
 // expose jquery to global context
 window.$ = $
@@ -29,76 +31,14 @@ $(document).ready(function() {
     });
 
     // Tree-expanding
+    if ($('table.tree-table').length) {
+        treeTable.initTreeTable();
+    };
 
-    // This fixes if there is a tree-balance, no balance and the row is not a parent.
-    // Without this code the tree-balance would not be shown.
-    $('table.tree-table tbody tr td:not(:first)').each(function(index, td) {
-        if ($(td).find('span.balance').length == 0) {
-            $(td).addClass('tree-balance-show');
-        }
-    });
-
-    function getLevel(tableRow) {
-        if ($(tableRow).length == 0) { return 0; }
-        var rowLevel = parseInt($(tableRow).attr('data-level'));
-        return rowLevel;
-    }
-
-    var level = 1;
-    $('table.tree-table tr').each(function() {
-        var nextLevel = getLevel($(this).next());
-        if (nextLevel <= level) { $(this).children().first().addClass('leaf'); }
-        level = nextLevel;
-    });
-
-    $('table.tree-table tr td:first-child:not(.leaf) a.account').each(function() {
-        $(this).append('<span class="expander" title="Hold the Shift-key while clicking to expand all children"></span>');
-    });
-
-    function toggleTreeTableRow(row, hide, all) {
-        var expander = row.find('span.expander');
-        var level = getLevel(row);
-        expander.toggleClass('toggled', hide);
-        row.toggleClass('hides', hide);
-        row = row.next();
-        while (row.length > 0 && getLevel(row) > level) {
-            if (hide == true) {
-                row.toggleClass('hidden', hide);
-                row.find('span.expander').removeClass('toggled');
-            } else if (all == true) {
-                row.toggleClass('hidden', hide);
-            } else {
-                    if (getLevel(row) == (level + 1)) {
-                        row.toggleClass('hides', !hide);
-                        row.toggleClass('hidden', hide);
-                        row.find('span.expander').addClass('toggled');
-                    }
-            }
-
-            row = row.next();
-        }
-    }
-
-    $('table.tree-table span.expander').click(function(e) {
-        var row = $(this).parents('tr');
-        var all = e.shiftKey == true;
-        toggleTreeTableRow(row, !row.hasClass('hides'), all);
-        $('table.tree-table a.expand-all').addClass('not-fully-expanded');
-        return false;
-    });
-
-    $('table.tree-table tr.hides').each(function() {
-        toggleTreeTableRow($(this), true, false);
-    });
-
-    $('table.tree-table').on('click', 'a.expand-all.not-fully-expanded', function(e) {
-        e.preventDefault();
-        var $this = $(e.target);
-        var row = $this.parents('table').find('tbody tr').first();
-        toggleTreeTableRow(row, false, true);
-        $this.removeClass('not-fully-expanded');
-        return false;
-    });
+    // Journal
+    if ($('#journal-table').length) {
+        journal.initJournal();
+    };
 
     // Keyboard shortcuts
 

--- a/fava/static/javascript/tree-table.js
+++ b/fava/static/javascript/tree-table.js
@@ -1,0 +1,73 @@
+function initTreeTable() { 
+    // This fixes if there is a tree-balance, no balance and the row is not a parent.
+    // Without this code the tree-balance would not be shown.
+    $('table.tree-table tbody tr td:not(:first)').each(function(index, td) {
+        if ($(td).find('span.balance').length == 0) {
+            $(td).addClass('tree-balance-show');
+        }
+    });
+
+    function getLevel(tableRow) {
+        if ($(tableRow).length == 0) { return 0; }
+        var rowLevel = parseInt($(tableRow).attr('data-level'));
+        return rowLevel;
+    }
+
+    var level = 1;
+    $('table.tree-table tr').each(function() {
+        var nextLevel = getLevel($(this).next());
+        if (nextLevel <= level) { $(this).children().first().addClass('leaf'); }
+        level = nextLevel;
+    });
+
+    $('table.tree-table tr td:first-child:not(.leaf) a.account').each(function() {
+        $(this).append('<span class="expander" title="Hold the Shift-key while clicking to expand all children"></span>');
+    });
+
+    function toggleTreeTableRow(row, hide, all) {
+        var expander = row.find('span.expander');
+        var level = getLevel(row);
+        expander.toggleClass('toggled', hide);
+        row.toggleClass('hides', hide);
+        row = row.next();
+        while (row.length > 0 && getLevel(row) > level) {
+            if (hide == true) {
+                row.toggleClass('hidden', hide);
+                row.find('span.expander').removeClass('toggled');
+            } else if (all == true) {
+                row.toggleClass('hidden', hide);
+            } else {
+                    if (getLevel(row) == (level + 1)) {
+                        row.toggleClass('hides', !hide);
+                        row.toggleClass('hidden', hide);
+                        row.find('span.expander').addClass('toggled');
+                    }
+            }
+
+            row = row.next();
+        }
+    }
+
+    $('table.tree-table span.expander').click(function(e) {
+        var row = $(this).parents('tr');
+        var all = e.shiftKey == true;
+        toggleTreeTableRow(row, !row.hasClass('hides'), all);
+        $('table.tree-table a.expand-all').addClass('not-fully-expanded');
+        return false;
+    });
+
+    $('table.tree-table tr.hides').each(function() {
+        toggleTreeTableRow($(this), true, false);
+    });
+
+    $('table.tree-table').on('click', 'a.expand-all.not-fully-expanded', function(e) {
+        e.preventDefault();
+        var $this = $(e.target);
+        var row = $this.parents('table').find('tbody tr').first();
+        toggleTreeTableRow(row, false, true);
+        $this.removeClass('not-fully-expanded');
+        return false;
+    });
+}
+
+module.exports.initTreeTable = initTreeTable;

--- a/fava/static/package.json
+++ b/fava/static/package.json
@@ -24,7 +24,6 @@
     "chartist-plugin-tooltip": "github:globegitter/chartist-plugin-tooltip",
     "clipboard": "^1.5.8",
     "compass-mixins": "^0.12.7",
-    "handlebars": "^4.0.5",
     "jquery": "^2.2.0",
     "jquery-query-object": "^2.2.3",
     "jquery-stupid-table": "github:medsabir/Stupid-Table-Plugin#feat-npm-publish",

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -20,7 +20,7 @@ html, body, html > body {
     min-width: 1235px;
 }
 
-.hidden {
+.hidden, .hidden-parent {
     display: none;
 }
 

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -20,7 +20,7 @@ html, body, html > body {
     min-width: 1235px;
 }
 
-.hidden, .hidden-parent {
+.hidden, .hidden-parent, .hidden-type, .hidden-parent-type {
     display: none;
 }
 

--- a/fava/static/sass/styles.scss
+++ b/fava/static/sass/styles.scss
@@ -584,7 +584,7 @@ article {
                     background-color: $color_onahau_approx;
                 }
 
-                &.transaction.warning {
+                &.transaction.uncleared {
                     background-color: $color_tickle_me_pink_approx;
                 }
 
@@ -765,6 +765,7 @@ article {
 
     .table-filter, .chart-filter {
         float: right;
+        clear: right;
         margin-bottom: 8px;
 
         input {

--- a/fava/static/sass/styles.scss
+++ b/fava/static/sass/styles.scss
@@ -617,7 +617,6 @@ article {
                     }
 
                     dl.metadata {
-                        display: none;
                         margin-top: 0;
                         padding: 2px 0 3px 6px;
                         margin: 4px 0 0 -6px;

--- a/fava/static/sass/styles.scss
+++ b/fava/static/sass/styles.scss
@@ -551,7 +551,7 @@ article {
                 }
 
                 &.close {
-                    background-color: $color_storm_dust_approx;
+                    background-color: $color_suva_gray_approx;
                 }
 
                 &.note {

--- a/fava/static/sass/styles.scss
+++ b/fava/static/sass/styles.scss
@@ -584,7 +584,7 @@ article {
                     background-color: $color_onahau_approx;
                 }
 
-                &.transaction.uncleared {
+                &.pending {
                     background-color: $color_tickle_me_pink_approx;
                 }
 

--- a/fava/static/webpack.config.js
+++ b/fava/static/webpack.config.js
@@ -7,7 +7,6 @@ module.exports = {
     'app': './javascript/main.js',
     'clipboard': './javascript/clipboard.js',
     'editor': './javascript/editor.js',
-    'journal': './javascript/journal.js',
     'styles': './sass/styles.scss'
   },
   output: {

--- a/fava/static/webpack.config.js
+++ b/fava/static/webpack.config.js
@@ -36,8 +36,4 @@ module.exports = {
       allChunks: true
     })
   ],
-  //for handlebars
-  node: {
-      fs: 'empty'
-  }
 }

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -51,7 +51,7 @@
 {%- endmacro %}
 
 
-  <table class="journal-table">
+  <table id="journal-table" class="journal-table">
         <thead>
             <tr>
                 <th class="datecell">Date</th>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -113,7 +113,7 @@
                     {% for tag in entry.tags %}<a href="{{ tag_url.replace('REPLACEME', tag) }}" title="Filter for tag #{{ tag }}"><span>#</span>{{ tag }}</a>{% endfor %}
                 {% endif %}
                 {% if entry.metadata %}
-                    <dl class="metadata"{% if show_metadata %} style="display: block;"{% endif %}>
+                    <dl class="metadata{% if not show_metadata %} hidden{% endif %}">
                         {% for key, value in entry.metadata.items() %}
                             <dt>{{ key }}</dt>
                             <dd>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -83,6 +83,9 @@
                 {% if type == 'open' %}
                     Open {{ account_link(entry.account) }}
                 {% endif %}
+                {% if type == 'close' %}
+                    Close {{ account_link(entry.account) }}
+                {% endif %}
                 {% if type == 'note' %}
                     Note: {{ entry.comment }}
                 {% endif %}

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -51,7 +51,6 @@
 {%- endmacro %}
 
 
-<div class="journal-table">
   <table class="journal-table">
         <thead>
             <tr>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -1,4 +1,5 @@
-{% set entry_types = ['open', 'close', 'transaction', 'balance', 'note', 'document', 'pad', 'padding', 'query'] %}
+{% set entry_types = ['open', 'close', 'transaction', 'balance', 'note', 'document', 'pad', 'query'] %}
+{% set transaction_types = ['cleared', 'uncleared', 'padding', 'summarize', 'transfer'] %}
 {% set show_type = {
     'open':        config.user.getboolean('journal-show-type-open'),
     'close':       config.user.getboolean('journal-show-type-close'),
@@ -7,15 +8,21 @@
     'note':        config.user.getboolean('journal-show-type-note'),
     'document':    config.user.getboolean('journal-show-type-document'),
     'pad':         config.user.getboolean('journal-show-type-pad'),
-    'padding':     config.user.getboolean('journal-show-type-padding'),
     'query':       config.user.getboolean('journal-show-type-query')
+} %}
+{% set show_transaction_type = {
+    'cleared':   config.user.getboolean('journal-show-transaction-cleared'),
+    'uncleared': config.user.getboolean('journal-show-transaction-uncleared'),
+    'padding':   config.user.getboolean('journal-show-transaction-padding'),
+    'summarize': config.user.getboolean('journal-show-transaction-summarize'),
+    'transfer':  config.user.getboolean('journal-show-transaction-transfer'),
 } %}
 
 {% set show_metadata= config.user.getboolean('journal-show-metadata') %}
 {% set show_legs = config.user.getboolean('journal-show-legs') %}
 
 {% if show_tablefilter %}
-    <div class="table-filter">
+    <div id="entry-filters" class="table-filter">
         <form>
             {% for type in entry_types %}
                 <input type="checkbox" value="{{ type }}" id="filter-{{ type }}" data-type="{{ type }}"{% if show_type[type] %} checked="checked"{% endif %}>
@@ -23,6 +30,14 @@
             {% endfor %}
             <input type="submit" id="toggle-metadata" value="{% if show_metadata %}Hide{% else %}Show{% endif %} metadata">
             <input type="submit" id="toggle-legs" value="{% if show_legs %}Hide{% else %}Show{% endif %} legs">
+        </form>
+    </div>
+    <div id="transaction-filters" class="table-filter">
+        <form>
+            {% for type in transaction_types %}
+                <input type="checkbox" value="{{ type }}" id="filter-{{ type }}" data-type="{{ type }}"{% if show_transaction_type[type] %} checked="checked"{% endif %}>
+                <label for="filter-{{ type }}">{{ type|capitalize }}</label>
+            {% endfor %}
         </form>
     </div>
 {% endif %}
@@ -56,35 +71,33 @@
         </thead>
         <tbody>
         {% for entry in journal %}
-            <tr class="{{ entry.meta.type }}
-            {%- if not show_type[entry.meta.type] %} hidden{% endif -%}
+            {% set type = entry.meta.type %}
+            <tr class="{{ type }} {{ entry.transaction_type }}
+            {%- if not show_type[type] %} hidden{% endif -%}
+            {%- if (entry.transaction_type and not show_transaction_type[entry.transaction_type]) %} hidden-type{% endif -%}
             {%- if entry.diff_amount %} fail{% endif -%}
-            {%- if entry.flag == '!'%} warning{% endif -%}
-            " data-type="{{ entry.meta.type -}}
+            " data-type="{{ type -}}
             " data-hash="{{ entry.hash -}}
             " title="{{ entry.meta.filename }}:{{ entry.meta.lineno }}">
                 <td class="datecell"><a href="{{ url_for('context', ehash=entry.hash) }}">{{ entry.date }}</a></td>
                 <td class="flag">{{ flag }}</td>
                 <td class="description" colspan="4">
-                {% if entry.meta.type == 'open' %}
+                {% if type == 'open' %}
                     Open <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>
                 {% endif %}
-                {% if entry.meta.type == 'note' %}
+                {% if type == 'note' %}
                     Note: {{ entry.comment }}
                 {% endif %}
-                {% if entry.meta.type == 'query' %}
+                {% if type == 'query' %}
                     Query: <a href="{{ url_for('query', query_hash=entry.hash) }}">{{ entry.name }}</a>
                 {% endif %}
-                {% if entry.meta.type == 'pad' %}
+                {% if type == 'pad' %}
                     Pad <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a> from <a href="{{ url_for('account_with_journal', name=entry.source_account) }}">{{ entry.source_account }}</a>
                 {% endif %}
-                {% if entry.meta.type == 'padding' %}
-                    {{ entry.narration }}
-                {% endif %}
-                {% if entry.meta.type == 'document' %}
+                {% if type == 'document' %}
                     Document for <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>: <a href="{{ url_for('document', file_path=entry.filename) }}">{{ entry.filename }}</a>
                 {% endif %}
-                {% if entry.meta.type == 'balance' %}
+                {% if type == 'balance' %}
                     Balance <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>
                     {% if diff_amount %} fails;
                         expected = {{ entry.amount|format_currency }} {{ entry.amount_currency }}
@@ -94,7 +107,7 @@
                         has {{ entry.amount }} {{ entry.amount_currency }}
                     {% endif %}
                 {% endif %}
-                {% if entry.meta.type == 'transaction' %}
+                {% if type == 'transaction' %}
                     <strong>{{ entry.payee or '' }}</strong>{% if entry.payee and entry.narration %} | {% endif %}{{ entry.narration or '' }}
                     {% for tag in entry.tags %}<a href="{{ url_for_current(tag=tag) }}" title="Filter for tag #{{ tag }}"><span>#</span>{{ tag }}</a>{% endfor %}
                 {% endif %}
@@ -129,7 +142,8 @@
                 {% endif %}
             </tr>
         {% for leg in entry.legs %}
-        <tr class="posting posting-{{ entry.meta.type }}{%- if not show_legs %} hidden{% endif -%}{%- if not show_type[entry.meta.type] %} hidden-parent{% endif -%}" data-parent-hash="{{ entry.hash }}" data-type="posting">
+        <tr class="posting posting-{{ entry.transaction_type }}{%- if not show_legs %} hidden{% endif -%}{%- if not show_type[type] %} hidden-parent{% endif -%}{%- if (type == 'transaction' and not show_transaction_type[entry.transaction_type]) %} hidden-parent-type{% endif -%}
+            " data-parent-hash="{{ entry.hash }}" data-type="posting">
                 <td class="datecell"></td>
                 <td class="flag"></td>
                 <td class="description"><a href="{{ url_for('account_with_journal', name=leg.account) }}">{{ leg.account }}</a></td>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -60,9 +60,6 @@
             {%- if not show_type[entry.meta.type] %} hidden{% endif -%}
             {%- if entry.diff_amount %} fail{% endif -%}
             {%- if entry.flag == '!'%} warning{% endif -%}
-            {%- if show_legs and entry.legs %} display-legs{% endif -%}
-            {%- if entry.metadata %} has-metadata{% endif -%}
-            " data-has-legs="{{ "True" if entry.legs else "False" -}}
             " data-type="{{ entry.meta.type -}}
             " data-hash="{{ entry.hash -}}
             " title="{{ entry.meta.filename }}:{{ entry.meta.lineno }}">
@@ -132,7 +129,7 @@
                 {% endif %}
             </tr>
         {% for leg in entry.legs %}
-        <tr class="posting leg leg-{{ entry.meta.type }} journal-entry-{{ entry.hash }}{%- if not show_type[entry.meta.type] %} hidden{% endif -%}">
+        <tr class="posting posting-{{ entry.meta.type }}{%- if not show_legs %} hidden{% endif -%}{%- if not show_type[entry.meta.type] %} hidden-parent{% endif -%}" data-parent-hash="{{ entry.hash }}" data-type="posting">
                 <td class="datecell"></td>
                 <td class="flag"></td>
                 <td class="description"><a href="{{ url_for('account_with_journal', name=leg.account) }}">{{ leg.account }}</a></td>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -1,26 +1,33 @@
-{% set entry_types = [('open',        config.user.getboolean('journal-show-type-open')),
-                      ('close',       config.user.getboolean('journal-show-type-close')),
-                      ('transaction', config.user.getboolean('journal-show-type-transaction')),
-                      ('balance',     config.user.getboolean('journal-show-type-balance')),
-                      ('note',        config.user.getboolean('journal-show-type-note')),
-                      ('document',    config.user.getboolean('journal-show-type-document')),
-                      ('pad',         config.user.getboolean('journal-show-type-pad')),
-                      ('padding',     config.user.getboolean('journal-show-type-padding')),
-                      ('query',       config.user.getboolean('journal-show-type-query'))] %}
+{% set entry_types = ['open', 'close', 'transaction', 'balance', 'note', 'document', 'pad', 'padding', 'query'] %}
+{% set show_type = {
+    'open':        config.user.getboolean('journal-show-type-open'),
+    'close':       config.user.getboolean('journal-show-type-close'),
+    'transaction': config.user.getboolean('journal-show-type-transaction'),
+    'balance':     config.user.getboolean('journal-show-type-balance'),
+    'note':        config.user.getboolean('journal-show-type-note'),
+    'document':    config.user.getboolean('journal-show-type-document'),
+    'pad':         config.user.getboolean('journal-show-type-pad'),
+    'padding':     config.user.getboolean('journal-show-type-padding'),
+    'query':       config.user.getboolean('journal-show-type-query')
+} %}
+
+{% set show_metadata= config.user.getboolean('journal-show-metadata') %}
+{% set show_legs = config.user.getboolean('journal-show-legs') %}
 
 {% if show_tablefilter %}
     <div class="table-filter">
         <form>
-            {% for type, default_checked in entry_types %}
-                <input type="checkbox" value="{{ type }}" id="filter-{{ type }}" data-type="{{ type }}"{% if default_checked %} checked="checked"{% endif %}>
+            {% for type in entry_types %}
+                <input type="checkbox" value="{{ type }}" id="filter-{{ type }}" data-type="{{ type }}"{% if show_type[type] %} checked="checked"{% endif %}>
                 <label for="filter-{{ type }}">{{ type|capitalize }}</label>
             {% endfor %}
-            <input type="submit" id="toggle-metadata" value="{% if config.user.getboolean('journal-show-metadata') %}Hide{% else %}Show{% endif %} metadata">
-            <input type="submit" id="toggle-legs" value="{% if config.user.getboolean('journal-show-legs') %}Hide{% else %}Show{% endif %} legs">
+            <input type="submit" id="toggle-metadata" value="{% if show_metadata %}Hide{% else %}Show{% endif %} metadata">
+            <input type="submit" id="toggle-legs" value="{% if show_legs %}Hide{% else %}Show{% endif %} legs">
         </form>
     </div>
 {% endif %}
 
+{#
 <script>
     window.contextURL = "{{ url_for('context', ehash='REPLACEME')|safe }}";
     window.accountURL = "{{ url_for('account_with_journal', name='REPLACEME')|safe }}";
@@ -28,25 +35,10 @@
     window.tagURL = "{{ url_for_current(tag='REPLACEME')|safe }}";
     window.documentURL = "{{ url_for('document', file_path='REPLACEME')|safe }}";
     window.journalURL = "{{ url_for('journal')|safe }}";
-
-{% if journal is defined %}
-    window.journalAsJSON = {{ journal|tojson|safe }};
-{% endif %}
-    window.journalShowChangeAndBalance = {{ show_change_and_balance|lower or 'false' }};
-    window.journalShowLegs = {{ config.user.getboolean('journal-show-legs')|lower }};
-    window.journalShowMetadata = {{ config.user.getboolean('journal-show-metadata')|lower }};
-    window.journalShowTypes = [
-        {% for type, default_checked in entry_types %}
-            {% if show_tablefilter %}{% if default_checked %}'{{ type }}',{% endif %}{% else %}'{{ type }}',{% endif %}
-        {% endfor %}
-    ];
 </script>
-<div class="journal-table">
-    <div class="loading">Loading journal entries&hellip;</div>
-</div>
+#}
 
-{% raw %}
-<script id="journal-table-template" type="text/x-handlebars-template">
+<div class="journal-table">
   <table class="journal-table">
         <thead>
             <tr>
@@ -56,125 +48,103 @@
                 <th class="position">Position</th>
                 <th class="price">Price</th>
                 <th class="cost">Cost</th>
-                {{#ifShowChangeAndBalance window}}
-                    <th class="change">Change</th>
-                    <th class="balance">Balance</th>
-                {{/ifShowChangeAndBalance}}
+                {% if show_change_and_balance %}
+                <th class="change">Change</th>
+                <th class="balance">Balance</th>
+                {% endif %}
             </tr>
         </thead>
         <tbody>
-        {{#each journal}}
-            {{#ifShowType window}}
-            <tr class="{{ meta.type }}{{#if diff_amount }} fail{{/if}}{{#ifCond flag '==' '!'}} warning{{/ifCond}}{{#ifShowLegs window}}{{#if legs }} display-legs{{/if}}{{/ifShowLegs}}{{#ifHasElements metadata }} has-metadata{{/ifHasElements}}" data-has-legs="{{#if legs }}True{{else}}False{{/if}}" data-type="{{ meta.type }}" data-hash="{{ hash }}" title="{{ meta.filename }}:{{ meta.lineno }}">
-                <td class="datecell"><a href="{{ context_url hash }}">{{ date }}</a></td>
+        {% for entry in journal %}
+            <tr class="{{ entry.meta.type }}
+            {%- if not show_type[entry.meta.type] %} hidden{% endif -%}
+            {%- if entry.diff_amount %} fail{% endif -%}
+            {%- if entry.flag == '!'%} warning{% endif -%}
+            {%- if show_legs and entry.legs %} display-legs{% endif -%}
+            {%- if entry.metadata %} has-metadata{% endif -%}
+            " data-has-legs="{{ "True" if entry.legs else "False" -}}
+            " data-type="{{ entry.meta.type -}}
+            " data-hash="{{ entry.hash -}}
+            " title="{{ entry.meta.filename }}:{{ entry.meta.lineno }}">
+                <td class="datecell"><a href="{{ url_for('context', ehash=entry.hash) }}">{{ entry.date }}</a></td>
                 <td class="flag">{{ flag }}</td>
                 <td class="description" colspan="4">
-                    {{#ifCond meta.type '==' 'open'}}
-                        <a href="{{ account_url account }}">{{ account }}</a>
-                    {{/ifCond}}
-                    {{#ifCond meta.type '==' 'note'}}
-                        Note: {{ comment }}
-                    {{/ifCond}}
-                    {{#ifCond meta.type '==' 'query'}}
-                        Query: <a href="{{ query_url hash }}">{{ name }}</a>
-                    {{/ifCond}}
-                    {{#ifCond meta.type '==' 'pad'}}
-                        Pad <a href="{{ account_url account }}">{{ account }}</a> from <a href="{{ account_url source_account }}">{{ source_account }}</a>
-                    {{/ifCond}}
-                    {{#ifCond meta.type '==' 'padding'}}
-                        {{ narration }}
-                    {{/ifCond}}
-                    {{#ifCond meta.type '==' 'document'}}
-                        Document for <a href="{{ account_url account }}">{{ account }}</a>: <a href="{{ document_url filename }}">{{ filename }}</a>
-                    {{/ifCond}}
-                    {{#ifCond meta.type '==' 'balance'}}
-                        Balance <a href="{{ account_url account }}">{{ account }}</a>
-                        {{#if diff_amount }} fails;
-                            expected =
-                            {{#each amount }}
-                                {{ format_currency this }} {{ @key }},
-                            {{/each}}
-                            balance =
-                            {{#each balance }}
-                                {{ format_currency this }} {{ @key }},
-                            {{/each}}
-                            difference =
-                            {{#each diff_amount }}
-                                {{ format_currency this }} {{ @key }}
-                            {{/each}}
-                        {{else}}
-                            has
-                            {{#each amount }}
-                                {{ format_currency this }} {{ @key }}<br>
-                            {{/each}}
-                        {{/if}}
-                    {{/ifCond}}
-                    {{#ifCond meta.type '==' 'transaction'}}
-                        <div class="narration">
-                            <strong>{{ payee }}</strong>
-                            {{#if payee }} {{#if narration }}<span>|</span>{{/if}} {{/if}}
-                            {{ narration }}
-                        </div>
-                        {{#if tags }}
-                            <div class="tags">
-                                {{#each tags }}<a href="{{ tag_url this }}" title="Filter for tag #{{ this }}"><span>#</span>{{ this }}</a>{{/each}}
-                            </div>
-                        {{/if}}
-                    {{/ifCond}}
-                    {{#ifHasElements metadata }}
-                        <dl class="metadata"{{#ifShowMetadata window}} style="display: block;"{{/ifShowMetadata}}>
-                            {{#each metadata }}
-                                <dt>{{ @key }}</dt>
-                                <dd>
-                                    {{#ifCond @key '==' 'statement' }}<a href="{{ document_url this }}">{{/ifCond}}
-                                    {{ this }}
-                                    {{#ifCond @key '==' 'statement' }}</a>{{/ifCond}}
-                                </dd>
-                            {{/each}}
-                        </dl>
-                    {{/ifHasElements}}
+                {% if entry.meta.type == 'open' %}
+                    Open <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>
+                {% endif %}
+                {% if entry.meta.type == 'note' %}
+                    Note: {{ entry.comment }}
+                {% endif %}
+                {% if entry.meta.type == 'query' %}
+                    Query: <a href="{{ url_for('query', query_hash=entry.hash) }}">{{ entry.name }}</a>
+                {% endif %}
+                {% if entry.meta.type == 'pad' %}
+                    Pad <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a> from <a href="{{ url_for('account_with_journal', name=entry.source_account) }}">{{ entry.source_account }}</a>
+                {% endif %}
+                {% if entry.meta.type == 'padding' %}
+                    {{ entry.narration }}
+                {% endif %}
+                {% if entry.meta.type == 'document' %}
+                    Document for <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>: <a href="{{ url_for('document', file_path=entry.filename) }}">{{ entry.filename }}</a>
+                {% endif %}
+                {% if entry.meta.type == 'balance' %}
+                    Balance <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>
+                    {% if diff_amount %} fails;
+                        expected = {{ entry.amount|format_currency }} {{ entry.amount_currency }}
+                        balance = {{ entry.balance|format_currency }} {{ entry.amount_currency }}
+                        difference = {{ entry.diff_amount|format_currency }} {{ entry.amount_currency }}
+                    {% else %}
+                        has {{ entry.amount }} {{ entry.amount_currency }}
+                    {% endif %}
+                {% endif %}
+                {% if entry.meta.type == 'transaction' %}
+                    <strong>{{ entry.payee or '' }}</strong>{% if entry.payee and entry.narration %} | {% endif %}{{ entry.narration or '' }}
+                    {% for tag in entry.tags %}<a href="{{ url_for_current(tag=tag) }}" title="Filter for tag #{{ tag }}"><span>#</span>{{ tag }}</a>{% endfor %}
+                {% endif %}
+                {% if entry.metadata %}
+                    <dl class="metadata"{% if show_metadata %} style="display: block;"{% endif %}>
+                        {% for key, value in entry.metadata %}
+                            <dt>{{ key }}</dt>
+                            <dd>
+                                {% if key == 'statement' %}<a href="{{ url_for('document', file_path=value)  }}">{% endif %}
+                                {{ value }}
+                                {% if key == 'statement' %}</a>{% endif %}
+                            </dd>
+                        {% endfor %}
+                    </dl>
+                {% endif %}
                 </td>
-                {{#ifShowChangeAndBalance window}}
+                {% if show_change_and_balance %}
                     <td class="change num">
-                        {{#if change }}
-                            {{#each change }}
-                                {{ format_currency this }} {{ @key }}<br>
-                            {{/each}}
-                        {{/if}}
+                    {% if entry.change %}
+                        {% for currency, number in entry.change.items() %}
+                            {{ number|format_currency }} {{ currency }}<br>
+                        {% endfor %}
+                    {% endif %}
                     </td>
                     <td class="balance num">
-                        {{#if balance }}
-                            {{#each balance }}
-                                {{ format_currency this }} {{ @key }}<br>
-                            {{/each}}
-                        {{/if}}
+                    {% if entry.balance %}
+                        {% for currency, number in entry.balance.items() %}
+                            {{ number|format_currency }} {{ currency }}<br>
+                        {% endfor %}
+                    {% endif %}
                     </td>
-                {{/ifShowChangeAndBalance}}
+                {% endif %}
             </tr>
-                {{#ifShowLegs window}}
-                    {{#with this as |journalEntry|}}
-                        {{> legPartialTemplate }}
-                    {{/with}}
-                {{/ifShowLegs}}
-            {{/ifShowType}}
-        {{/each}}
-        </tbody>
-    </table>
-</script>
-<script id="journal-leg-template" type="text/x-handlebars-template">
-    {{#each legs }}
-        <tr class="posting leg" data-type="leg" data-parent-hash="{{ ../hash }}">
-            <td class="datecell"></td>
-            <td class="flag"></td>
-            <td class="description"><a href="{{ account_url account }}">{{ account }}</a></td>
-            <td class="position num">{{ position }} {{ position_currency }}</td>
-            <td class="price num">{{ price }} {{ price_currency }}</td>
-            <td class="cost num">{{ cost }} {{ cost_currency }}</td>
-            {{#ifShowChangeAndBalance window}}
+        {% for leg in entry.legs %}
+        <tr class="posting leg leg-{{ entry.meta.type }} journal-entry-{{ entry.hash }}{%- if not show_type[entry.meta.type] %} hidden{% endif -%}">
+                <td class="datecell"></td>
+                <td class="flag"></td>
+                <td class="description"><a href="{{ url_for('account_with_journal', name=leg.account) }}">{{ leg.account }}</a></td>
+                <td class="position num">{{ leg.units.number|format_currency }} {{ leg.units.currency }}</td>
+                <td class="price num">{{ leg.price.number|format_currency }} {{ leg.price.currency }}</td>
+                <td class="cost num">{{ leg.cost.number|format_currency }} {{ leg.cost.currency }}</td>
+                {% if show_change_and_balance %}
                 <td class="change num"></td>
                 <td class="balance num"></td>
-            {{/ifShowChangeAndBalance}}
-        </tr>
-    {{/each}}
-</script>
-{% endraw %}
+                {% endif %}
+            </tr>
+        {% endfor %}
+    {% endfor %}
+        </tbody>
+    </table>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -73,6 +73,7 @@
             {%- if not show_type[type] %} hidden{% endif -%}
             {%- if (entry.transaction_type and not show_transaction_type[entry.transaction_type]) %} hidden-type{% endif -%}
             {%- if entry.diff_amount %} fail{% endif -%}
+            {%- if entry.metadata|length > 0 %} has-metadata{% endif -%}
             " data-type="{{ type -}}
             " data-hash="{{ entry.hash -}}
             " title="{{ entry.meta.filename }}:{{ entry.meta.lineno }}">
@@ -113,7 +114,7 @@
                 {% endif %}
                 {% if entry.metadata %}
                     <dl class="metadata"{% if show_metadata %} style="display: block;"{% endif %}>
-                        {% for key, value in entry.metadata %}
+                        {% for key, value in entry.metadata.items() %}
                             <dt>{{ key }}</dt>
                             <dd>
                                 {% if key == 'statement' %}<a href="{{ url_for('document', file_path=value)  }}">{% endif %}

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -78,7 +78,7 @@
             " data-hash="{{ entry.hash -}}
             " title="{{ entry.meta.filename }}:{{ entry.meta.lineno }}">
                 <td class="datecell"><a href="{{ context_url.replace('REPLACEME', entry.hash) }}">{{ entry.date }}</a></td>
-                <td class="flag">{{ flag }}</td>
+                <td class="flag">{{ entry.flag }}</td>
                 <td class="description" colspan="4">
                 {% if type == 'open' %}
                     Open {{ account_link(entry.account) }}

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -18,7 +18,7 @@
     'transfer':  config.user.getboolean('journal-show-transaction-transfer'),
 } %}
 
-{% set show_metadata= config.user.getboolean('journal-show-metadata') %}
+{% set show_metadata = config.user.getboolean('journal-show-metadata') %}
 {% set show_legs = config.user.getboolean('journal-show-legs') %}
 
 {% if show_tablefilter %}
@@ -42,16 +42,14 @@
     </div>
 {% endif %}
 
-{#
-<script>
-    window.contextURL = "{{ url_for('context', ehash='REPLACEME')|safe }}";
-    window.accountURL = "{{ url_for('account_with_journal', name='REPLACEME')|safe }}";
-    window.queryURL = "{{ url_for('query', query_hash='REPLACEME')|safe }}";
-    window.tagURL = "{{ url_for_current(tag='REPLACEME')|safe }}";
-    window.documentURL = "{{ url_for('document', file_path='REPLACEME')|safe }}";
-    window.journalURL = "{{ url_for('journal')|safe }}";
-</script>
-#}
+{% set context_url = url_for('context', ehash='REPLACEME') %}
+{% set account_url = url_for('account_with_journal', name='REPLACEME') %}
+{% set tag_url = url_for_current(tag='REPLACEME') %}
+
+{% macro account_link(name) -%}
+<a href="{{ account_url.replace('REPLACEME', name) }}">{{ name }}</a>
+{%- endmacro %}
+
 
 <div class="journal-table">
   <table class="journal-table">
@@ -79,11 +77,11 @@
             " data-type="{{ type -}}
             " data-hash="{{ entry.hash -}}
             " title="{{ entry.meta.filename }}:{{ entry.meta.lineno }}">
-                <td class="datecell"><a href="{{ url_for('context', ehash=entry.hash) }}">{{ entry.date }}</a></td>
+                <td class="datecell"><a href="{{ context_url.replace('REPLACEME', entry.hash) }}">{{ entry.date }}</a></td>
                 <td class="flag">{{ flag }}</td>
                 <td class="description" colspan="4">
                 {% if type == 'open' %}
-                    Open <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>
+                    Open {{ account_link(entry.account) }}
                 {% endif %}
                 {% if type == 'note' %}
                     Note: {{ entry.comment }}
@@ -92,13 +90,13 @@
                     Query: <a href="{{ url_for('query', query_hash=entry.hash) }}">{{ entry.name }}</a>
                 {% endif %}
                 {% if type == 'pad' %}
-                    Pad <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a> from <a href="{{ url_for('account_with_journal', name=entry.source_account) }}">{{ entry.source_account }}</a>
+                    Pad {{ account_link(entry.account) }} from {{ account_link(entry.source_account) }}
                 {% endif %}
                 {% if type == 'document' %}
-                    Document for <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>: <a href="{{ url_for('document', file_path=entry.filename) }}">{{ entry.filename }}</a>
+                    Document for {{ account_link(entry.account) }}: <a href="{{ url_for('document', file_path=entry.filename) }}">{{ entry.filename }}</a>
                 {% endif %}
                 {% if type == 'balance' %}
-                    Balance <a href="{{ url_for('account_with_journal', name=entry.account) }}">{{ entry.account }}</a>
+                    Balance {{ account_link(entry.account) }}
                     {% if diff_amount %} fails;
                         expected = {{ entry.amount|format_currency }} {{ entry.amount_currency }}
                         balance = {{ entry.balance|format_currency }} {{ entry.amount_currency }}
@@ -109,7 +107,7 @@
                 {% endif %}
                 {% if type == 'transaction' %}
                     <strong>{{ entry.payee or '' }}</strong>{% if entry.payee and entry.narration %} | {% endif %}{{ entry.narration or '' }}
-                    {% for tag in entry.tags %}<a href="{{ url_for_current(tag=tag) }}" title="Filter for tag #{{ tag }}"><span>#</span>{{ tag }}</a>{% endfor %}
+                    {% for tag in entry.tags %}<a href="{{ tag_url.replace('REPLACEME', tag) }}" title="Filter for tag #{{ tag }}"><span>#</span>{{ tag }}</a>{% endfor %}
                 {% endif %}
                 {% if entry.metadata %}
                     <dl class="metadata"{% if show_metadata %} style="display: block;"{% endif %}>
@@ -146,7 +144,7 @@
             " data-parent-hash="{{ entry.hash }}" data-type="posting">
                 <td class="datecell"></td>
                 <td class="flag"></td>
-                <td class="description"><a href="{{ url_for('account_with_journal', name=leg.account) }}">{{ leg.account }}</a></td>
+                <td class="description">{{ account_link(leg.account) }}</td>
                 <td class="position num">{{ leg.units.number|format_currency }} {{ leg.units.currency }}</td>
                 <td class="price num">{{ leg.price.number|format_currency }} {{ leg.price.currency }}</td>
                 <td class="cost num">{{ leg.cost.number|format_currency }} {{ leg.cost.currency }}</td>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -1,5 +1,5 @@
 {% set entry_types = ['open', 'close', 'transaction', 'balance', 'note', 'document', 'pad', 'query'] %}
-{% set transaction_types = ['cleared', 'uncleared', 'padding', 'summarize', 'transfer'] %}
+{% set transaction_types = ['cleared', 'pending', 'padding', 'summarize', 'transfer', 'other'] %}
 {% set show_type = {
     'open':        config.user.getboolean('journal-show-type-open'),
     'close':       config.user.getboolean('journal-show-type-close'),
@@ -12,10 +12,11 @@
 } %}
 {% set show_transaction_type = {
     'cleared':   config.user.getboolean('journal-show-transaction-cleared'),
-    'uncleared': config.user.getboolean('journal-show-transaction-uncleared'),
+    'pending':   config.user.getboolean('journal-show-transaction-pending'),
     'padding':   config.user.getboolean('journal-show-transaction-padding'),
     'summarize': config.user.getboolean('journal-show-transaction-summarize'),
     'transfer':  config.user.getboolean('journal-show-transaction-transfer'),
+    'other':     config.user.getboolean('journal-show-transaction-other'),
 } %}
 
 {% set show_metadata = config.user.getboolean('journal-show-metadata') %}
@@ -142,7 +143,7 @@
                     </td>
                 {% endif %}
             </tr>
-        {% for leg in entry.legs %}
+        {% for leg in entry.postings %}
         <tr class="posting posting-{{ entry.transaction_type }}{%- if not show_legs %} hidden{% endif -%}{%- if not show_type[type] %} hidden-parent{% endif -%}{%- if (type == 'transaction' and not show_transaction_type[entry.transaction_type]) %} hidden-parent-type{% endif -%}
             " data-parent-hash="{{ entry.hash }}" data-type="posting">
                 <td class="datecell"></td>

--- a/fava/templates/_keyboard_shortcuts.html
+++ b/fava/templates/_keyboard_shortcuts.html
@@ -38,19 +38,21 @@
                 <kbd>f</kbd> then <kbd>p</kbd>: Filter by Payee     (pull down menu)
             </p>
             <p>
-                <strong>Options in transaction pages:</strong><br>
-                <kbd>l</kbd>: show/hide legs<br>
-                <kbd>s</kbd> then <kbd>l</kbd>: show/hide legs<br>
-                <kbd>m</kbd>: show/hide metadata<br>
-                <kbd>s</kbd> then <kbd>m</kbd>: show/hide metadata<br>
-                <kbd>s</kbd> then <kbd>o</kbd>: show/hide open<br>
-                <kbd>s</kbd> then <kbd>c</kbd>: show/hide close<br>
-                <kbd>s</kbd> then <kbd>t</kbd>: show/hide transaction<br>
-                <kbd>s</kbd> then <kbd>b</kbd>: show/hide balance<br>
-                <kbd>s</kbd> then <kbd>n</kbd>: show/hide note<br>
-                <kbd>s</kbd> then <kbd>d</kbd>: show/hide document<br>
-                <kbd>s</kbd> then <kbd>p</kbd>: show/hide pad<br>
-                <kbd>s</kbd> then <kbd>P</kbd>: show/hide padding
+                <strong>Toggle journal entries:</strong><br>
+                <kbd>l</kbd>: Legs<br>
+                <kbd>m</kbd>: Metadata<br>
+                <kbd>s</kbd> then <kbd>o</kbd>: Open directives<br>
+                <kbd>s</kbd> then <kbd>c</kbd>: Close directives<br>
+                <kbd>s</kbd> then <kbd>t</kbd>: Transactions<br>
+                <kbd>s</kbd> then <kbd>b</kbd>: Balances<br>
+                <kbd>s</kbd> then <kbd>n</kbd>: Notes<br>
+                <kbd>s</kbd> then <kbd>d</kbd>: Document<br>
+                <kbd>s</kbd> then <kbd>p</kbd>: Pad directives<br>
+                <kbd>t</kbd> then <kbd>p</kbd>: Cleared transactions<br>
+                <kbd>t</kbd> then <kbd>u</kbd>: Uncleared/Pending transactions<br>
+                <kbd>t</kbd> then <kbd>p</kbd>: Padding transactions<br>
+                <kbd>t</kbd> then <kbd>s</kbd>: Summarize transactions<br>
+                <kbd>t</kbd> then <kbd>t</kbd>: Transfer transactions<br>
             </p>
         </div>
     </div>

--- a/fava/templates/_keyboard_shortcuts.html
+++ b/fava/templates/_keyboard_shortcuts.html
@@ -48,11 +48,14 @@
                 <kbd>s</kbd> then <kbd>n</kbd>: Notes<br>
                 <kbd>s</kbd> then <kbd>d</kbd>: Document<br>
                 <kbd>s</kbd> then <kbd>p</kbd>: Pad directives<br>
-                <kbd>t</kbd> then <kbd>p</kbd>: Cleared transactions<br>
-                <kbd>t</kbd> then <kbd>u</kbd>: Uncleared/Pending transactions<br>
-                <kbd>t</kbd> then <kbd>p</kbd>: Padding transactions<br>
+            </p>
+            <p>
+                <kbd>t</kbd> then <kbd>c</kbd>: Cleared transactions<br>
+                <kbd>t</kbd> then <kbd>p</kbd>: Pending transactions<br>
+                <kbd>t</kbd> then <kbd>P</kbd>: Padding transactions<br>
                 <kbd>t</kbd> then <kbd>s</kbd>: Summarize transactions<br>
                 <kbd>t</kbd> then <kbd>t</kbd>: Transfer transactions<br>
+                <kbd>t</kbd> then <kbd>o</kbd>: Other transactions<br>
             </p>
         </div>
     </div>

--- a/fava/templates/_keyboard_shortcuts.html
+++ b/fava/templates/_keyboard_shortcuts.html
@@ -1,4 +1,4 @@
-<div class="overlay-wrapper">
+<div id="overlay-wrapper" class="overlay-wrapper">
     <div class="overlay">
         <a href="#close" class="close">(close)</a>
         <h1>Keyboard shortcuts</h1>

--- a/fava/templates/account.html
+++ b/fava/templates/account.html
@@ -5,12 +5,6 @@
 
 {% block title %}Account {{ account_name }}{% endblock %}
 
-{% block javascript %}
-    {% if not interval %}
-        {% include "javascript/_journal.html" %}
-    {% endif %}
-{% endblock %}
-
 {% block content %}
     {{ account_macros.account_name_header(account_name) }}
 

--- a/fava/templates/charts/_chart_skeleton.html
+++ b/fava/templates/charts/_chart_skeleton.html
@@ -7,5 +7,5 @@
     <div class="charts-container"{% if not config.user.getboolean('charts-show') %} style="display: none"{% endif %}>
         <div class="loading">Loading charts&hellip;</div>
     </div>
-    <div class="chart-labels"{% if not config.user.getboolean('charts-show') %} style="display: none"{% endif %}> </div>
+    <div id="chart-labels" class="chart-labels"{% if not config.user.getboolean('charts-show') %} style="display: none"{% endif %}> </div>
 </div>

--- a/fava/templates/context.html
+++ b/fava/templates/context.html
@@ -5,7 +5,6 @@
 
 {% block javascript %}
     {% include "javascript/_editor.html" %}
-    {% include "javascript/_journal.html" %}
 {% endblock %}
 
 {% block content %}

--- a/fava/templates/documents.html
+++ b/fava/templates/documents.html
@@ -1,8 +1,6 @@
 {% extends "_layout.html" %}
 {% set active_page = 'documents' %}
 
-{% block javascript %}{% include "javascript/_journal.html" %}{% endblock %}
-
 {% block content %}
     <h1>Documents</h1>
     {% set documents = api.documents() %}

--- a/fava/templates/javascript/_journal.html
+++ b/fava/templates/javascript/_journal.html
@@ -1,1 +1,0 @@
-<script type="text/javascript" src="{{ url_for('static', filename='gen/journal.js') }}"></script>

--- a/fava/templates/journal.html
+++ b/fava/templates/journal.html
@@ -1,11 +1,9 @@
 {% extends "_layout.html" %}
 {% set active_page = 'journal' %}
 
-{% block javascript %}{% include "javascript/_journal.html" %}{% endblock %}
-
 {% block content %}
     <h1>General Ledger</h1>
-    {% with show_tablefilter=True, show_change_and_balance=config.user.getboolean('journal-general-show-balances')  %}
+    {% with journal = api.journal(), show_tablefilter=True, show_change_and_balance=config.user.getboolean('journal-general-show-balances')  %}
         {% include "_journal_table.html" %}
     {% endwith %}
 {% endblock %}

--- a/fava/templates/journal.html
+++ b/fava/templates/journal.html
@@ -1,6 +1,8 @@
 {% extends "_layout.html" %}
 {% set active_page = 'journal' %}
 
+{% block javascript %}{% include "javascript/_journal.html" %}{% endblock %}
+
 {% block content %}
     <h1>General Ledger</h1>
     {% with journal = api.journal(), show_tablefilter=True, show_change_and_balance=config.user.getboolean('journal-general-show-balances')  %}

--- a/fava/templates/journal.html
+++ b/fava/templates/journal.html
@@ -1,8 +1,6 @@
 {% extends "_layout.html" %}
 {% set active_page = 'journal' %}
 
-{% block javascript %}{% include "javascript/_journal.html" %}{% endblock %}
-
 {% block content %}
     <h1>General Ledger</h1>
     {% with journal = api.journal(), show_tablefilter=True, show_change_and_balance=config.user.getboolean('journal-general-show-balances')  %}

--- a/fava/templates/notes.html
+++ b/fava/templates/notes.html
@@ -1,8 +1,6 @@
 {% extends "_layout.html" %}
 {% set active_page = 'notes' %}
 
-{% block javascript %}{% include "javascript/_journal.html" %}{% endblock %}
-
 {% block content %}
     <h1>Notes</h1>
     {% set notes = api.notes() %}


### PR DESCRIPTION
I've never been really happy with doing the templating of the journal in Javascript as we loose all the beancount Python objects that we can easily and correctly deal with in Jinja. Also it didn't really feel much faster for me as it introduced the additional delay of loading the page first, parsing the Javascript and only then running the template. Since the beancount API changes, the journal was broken, so this seemed like a good time to work on this and also add some missing directives to the journal.

I've reimplemented the journal in Python. After making some performance improvement (mostly just caching `url_for` and some attributes), load time for me is now about half of what the Javascript took to complete.

The speed of the toggle checkboxes has also massively been improved as the journal doesn't have to be re-rendered every time. There are now separate toggle boxes for different transaction types like paddings (a padding is not a different kind of directive, but rather a specific transaction). This also means that there are some more configuration options.

One other thing that might improve the responsiveness of the page would be to use a list instead of a table (table redraws are more time-expensive, as a wide column at the bottom might change the whole layout), which could enable even quicker page-loads (or at least they would feel quicker as the rendering could start instantly). Maybe better left for a different PR though.