### PR TITLE
JS refactorings

### DIFF
--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -7,39 +7,40 @@ require('jquery-treemap/src/jquery-treemap');
 
 require('./helpers');
 
-$(document).ready(function() {
-    $('.charts-container').html('');
+var defaultOptions = {
+    height: 240,
+    chartPadding: { left: 3 },
+    axisY: {
+        onlyInteger: true,
+        position: 'end',
+        scaleMinSpace: 15,
+        labelInterpolationFnc: function(value) {
+            return value;
+        },
+        referenceValue: 0,
+    },
+    plugins: [
+        Chartist.plugins.legend(),
+        Chartist.plugins.tooltip({
+            tooltipFnc: function(meta, value){
+                return decodeEntities(meta);
+            }
+        })
+    ]
+};
+
+module.exports.initCharts = function() {
+    var container = $('#chart-container');
+    var labels = $('#chart-labels');
+    container.html('');
     window.chartData.charts = {}
 
     $.each(window.chartData, function(index, chart) {
         chart.id = "chart-" + index;
         chart.options = $.extend({}, chart.options);
 
-        $('.charts-container').append('<div class="ct-chart" id="' + chart.id + '"></div>');
-        var divider = $('.chart-labels').children().length > 0 ? " | " : "";
-        $('.chart-labels').append(divider + '<label for="' + chart.id + '">' + chart.label + '</label>');
-
-        var defaultOptions = {
-            height: 240,
-            chartPadding: { left: 3 },
-            axisY: {
-                onlyInteger: true,
-                position: 'end',
-                scaleMinSpace: 15,
-                labelInterpolationFnc: function(value) {
-                    return value;
-                },
-                referenceValue: 0,
-            },
-            plugins: [
-                Chartist.plugins.legend(),
-                Chartist.plugins.tooltip({
-                    tooltipFnc: function(meta, value){
-                        return decodeEntities(meta);
-                    }
-                })
-            ]
-        };
+        container.append('<div class="ct-chart" id="' + chart.id + '"></div>');
+        labels.append('<label for="' + chart.id + '">' + chart.label + '</label>');
 
         switch(chart.type) {
             case 'line':
@@ -167,31 +168,25 @@ $(document).ready(function() {
     });
 
     // Toggle multiple charts
-    $('.charts .chart-labels label').click(function() {
+    labels.find('label').click(function() {
         var chartId = $(this).prop('for');
         $('.charts .ct-chart').addClass('hidden')
         $('.charts .ct-chart#' + chartId).removeClass('hidden');
 
-        $('.charts .chart-labels label').removeClass('selected');
+        labels.find('label').removeClass('selected');
         $(this).addClass('selected');
 
         if (window.chartData.charts[chartId] !== undefined) {
             window.chartData.charts[chartId].update();
         }
     });
-    $('.charts .chart-labels label:first-child').click();
+    labels.find('label:first-child').click();
 
     // Toggle chart by clicking on "Hide/Show chart"
-    $('.charts input#toggle-chart').click(function() {
-        $('.charts-container, .chart-labels').toggle($(this).hasClass('hide-charts'));
-        $(this).toggleClass('hide-charts');
-
-        var text = $(this).prop('value');
-        $(this).prop('value', text === 'Hide charts' ? 'Show charts' : 'Hide charts');
-
-        return false;
+    $('#toggle-chart').click(function() {
+        event.preventDefault();
+        var shouldShow = ($(this).val() == 'Show charts');
+        $('#chart-container, #chart-labels').toggleClass('hidden', !shouldShow);
+        $(this).val(shouldShow ? 'Hide charts' : 'Show charts');
     });
-});
-
-
-
+}

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -5,7 +5,7 @@ require('./vendor/chartist-plugin-zoom');
 
 require('jquery-treemap/src/jquery-treemap');
 
-require('./helpers');
+var helpers = require('./helpers');
 
 var defaultOptions = {
     height: 240,
@@ -49,7 +49,7 @@ module.exports.initCharts = function() {
                         type: Chartist.AutoScaleAxis,
                         scaleMinSpace: 25,
                         labelInterpolationFnc: function(value, index) {
-                            var val = isNumber(value) ? new Date(value) : value;
+                            var val = helpers.isNumber(value) ? new Date(value) : value;
                             return val.formatWithString(chart.options.dateFormat ? chart.options.dateFormat : "MMM 'YY");
                         }
                     },
@@ -61,8 +61,8 @@ module.exports.initCharts = function() {
                         var dateStart = new Date(chart.options.axisX.highLow.low);
                         var dateEnd = new Date(chart.options.axisX.highLow.high);
 
-                        var dateStringStart = '' + dateStart.getFullYear() + '-' + (pad(dateStart.getMonth()+1));
-                        var dateStringEnd = '' + dateEnd.getFullYear() + '-' + (pad(dateEnd.getMonth()+1));
+                        var dateStringStart = '' + dateStart.getFullYear() + '-' + (helpers.pad(dateStart.getMonth()+1));
+                        var dateStringEnd = '' + dateEnd.getFullYear() + '-' + (helpers.pad(dateEnd.getMonth()+1));
                         var e = $.Event('keyup');
                         e.which = 13;
                         $("#filter-time input[type=search]").val(dateStringStart + ' - ' + dateStringEnd).trigger(e);
@@ -78,7 +78,7 @@ module.exports.initCharts = function() {
                     axisX: {
                         labelInterpolationFnc: function(value, index) {
                             if (chart.data.labels.length <= 25 || index % Math.ceil(chart.data.labels.length / 25) === 0) {
-                                var val = isNumber(value) ? new Date(value) : value;
+                                var val = helpers.isNumber(value) ? new Date(value) : value;
                                 return val.formatWithString(chart.options.dateFormat ? chart.options.dateFormat : "MMM 'YY");
                             } else {
                                 return null;
@@ -95,8 +95,8 @@ module.exports.initCharts = function() {
                         var dateStart = new Date(chart.data.labels[Math.floor(x1 / pxPerBar)]);
                         var dateEnd = new Date(chart.data.labels[Math.floor(x2 / pxPerBar)]);
 
-                        var dateStringStart = '' + dateStart.getFullYear() + '-' + (pad(dateStart.getMonth()+1));
-                        var dateStringEnd = '' + dateEnd.getFullYear() + '-' + (pad(dateEnd.getMonth()+1));
+                        var dateStringStart = '' + dateStart.getFullYear() + '-' + (helpers.pad(dateStart.getMonth()+1));
+                        var dateStringEnd = '' + dateEnd.getFullYear() + '-' + (helpers.pad(dateEnd.getMonth()+1));
                         var e = $.Event('keyup');
                         e.which = 13;
                         $("#filter-time input[type=search]").val(dateStringStart + ' - ' + dateStringEnd).trigger(e);
@@ -110,7 +110,7 @@ module.exports.initCharts = function() {
 
                 $(chart.container).on('click', '.ct-bar', function() {
                     var date = chart.data.labels[$(event.target).index()];
-                    var dateString = '' + date.getFullYear() + '-' + (pad(date.getMonth()+1));
+                    var dateString = '' + date.getFullYear() + '-' + (helpers.pad(date.getMonth()+1));
                     var e = $.Event('keyup');
                     e.which = 13;
                     $("#filter-time input[type=search]").val(dateString).trigger(e);

--- a/fava/static/javascript/clipboard.js
+++ b/fava/static/javascript/clipboard.js
@@ -1,6 +1,6 @@
 var Clipboard = require('clipboard');
 
-$(document).ready(function() {
+module.exports.initClipboard = function() {
     new Clipboard('.status-indicator');
     new Clipboard('#copy-balances', {
         text: function(trigger) {
@@ -9,4 +9,4 @@ $(document).ready(function() {
             return text.join('\n').trim();
         }
     });
-});
+};

--- a/fava/static/javascript/filters.js
+++ b/fava/static/javascript/filters.js
@@ -1,0 +1,32 @@
+module.exports.initFilters = function(){
+    $('.filter input').keyup(function() {
+        var $this = $(this);
+        var value = $this.val();
+        $(this).parents('.filter').find('li.suggestion').toggle(value == '');
+        $(this).parents('.filter').find("li[data-filter*='" + value.toLowerCase() + "']").show();
+    });
+
+    $('.filter#filter-time input').keyup(function(e) {
+        var $this = $(this);
+        var code = e.which;
+        if (code == 13) {
+            e.preventDefault();
+            window.location.href = location.pathname + ($.query.set('time', $this.val()));
+        }
+    });
+
+    $("body").click(function(){
+        $("ul.topmenu li").removeClass("opened");
+    });
+
+    $("ul.topmenu li").click(function(e){
+        e.stopPropagation();
+    });
+
+    $('ul.topmenu input[type=search]').keyup(function(e) {
+        if (e.which == 27) {
+            $(this).blur();
+            $(this).parents('li').removeClass("opened");
+        }
+    });
+};

--- a/fava/static/javascript/helpers.js
+++ b/fava/static/javascript/helpers.js
@@ -1,9 +1,3 @@
-$.expr[":"].contains = $.expr.createPseudo(function(arg) {
-    return function( elem ) {
-        return $(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;
-    };
-});
-
 //  Checks that string starts with the specific string
 if (typeof String.prototype.startsWith != 'function') {
     String.prototype.startsWith = function (str) {
@@ -79,8 +73,8 @@ if (typeof Date.prototype.formatWithString != 'function') {
 }
 
 // http://stackoverflow.com/a/7195920
-window.isNumber = function(num) {
+module.exports.isNumber = function(num) {
     return (typeof num == 'string' || typeof num == 'number') && !isNaN(num - 0) && num !== '';
 };
 
-window.pad = function(n) { return n < 10 ? '0' + n : n };
+module.exports.pad = function(n) { return n < 10 ? '0' + n : n };

--- a/fava/static/javascript/helpers.js
+++ b/fava/static/javascript/helpers.js
@@ -1,11 +1,3 @@
-// Fix sidebar styling
-$(document).ready(function() {
-    var mainHeight = $('.main').outerHeight();
-    var minHeight = $(window).height() - $('header').offset().top - $('header').outerHeight();
-    var sidebarHeight = $('aside').outerHeight();
-    $('.main, aside').css('min-height', Math.max(mainHeight, minHeight, sidebarHeight) + 'px');
-});
-
 $.expr[":"].contains = $.expr.createPseudo(function(arg) {
     return function( elem ) {
         return $(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;

--- a/fava/static/javascript/journal.js
+++ b/fava/static/javascript/journal.js
@@ -26,7 +26,7 @@ module.exports.initJournal = function() {
     });
 
     // Button "Hide/Show legs"
-    $('input#toggle-legs').click(function(event) {
+    $('#toggle-legs').click(function(event) {
         event.preventDefault();
         var shouldShow = ($(this).val() == 'Show legs');
         $('#journal-table tr[data-type="posting"]').toggleClass('hidden', !shouldShow);
@@ -34,7 +34,7 @@ module.exports.initJournal = function() {
     });
 
     // Button "Hide/Show metadata"
-    $('input#toggle-metadata').click(function(event) {
+    $('#toggle-metadata').click(function(event) {
         event.preventDefault();
         var shouldShow = ($(this).val() == 'Show metadata');
         $('#journal-table dl.metadata').toggleClass('hidden', !shouldShow);

--- a/fava/static/javascript/journal.js
+++ b/fava/static/javascript/journal.js
@@ -1,13 +1,10 @@
-function initJournal() {
+module.exports.initJournal = function() {
     // Toggle legs by clicking on transaction/padding row
     $('#journal-table tr[data-type="transaction"]').click(function() {
         var hash = $(this).attr('data-hash');
         $('#journal-table tr[data-parent-hash="' + hash + '"]').toggleClass("hidden");
     });
-    initJournalFilters();
-}
 
-function initJournalFilters() {
     // Toggle entries with checkboxes
     $('#entry-filters input[type="checkbox"]').change(function() {
         var $this = $(this);
@@ -44,5 +41,3 @@ function initJournalFilters() {
         $(this).val(shouldShow ? 'Hide metadata' : 'Show metadata');
     });
 }
-
-module.exports.initJournal = initJournal;

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -5,6 +5,7 @@ window.Mousetrap = require('mousetrap');
 require('mousetrap/plugins/bind-dictionary/mousetrap-bind-dictionary');
 
 require('./charts');
+var filters = require('./filters');
 var journal = require('./journal');
 var treeTable = require('./tree-table');
 
@@ -14,21 +15,8 @@ window.$ = $
 $(document).ready(function() {
     $("table.sortable").stupidtable();
 
-    $('.filter input').keyup(function() {
-        var $this = $(this);
-        var value = $this.val();
-        $(this).parents('.filter').find('li.suggestion').toggle(value == '');
-        $(this).parents('.filter').find("li[data-filter*='" + value.toLowerCase() + "']").show();
-    });
-
-    $('.filter#filter-time input').keyup(function(e) {
-        var $this = $(this);
-        var code = e.which;
-        if (code == 13) {
-            e.preventDefault();
-            window.location.href = location.pathname + ($.query.set('time', $this.val()));
-        }
-    });
+    // Setup filters form
+    filters.initFilters();
 
     // Tree-expanding
     if ($('table.tree-table').length) {
@@ -41,22 +29,6 @@ $(document).ready(function() {
     };
 
     // Keyboard shortcuts
-
-    // Filtering:
-    $("body").click(function(){
-        $("ul.topmenu li").removeClass("opened");
-    });
-
-    $("ul.topmenu li").click(function(e){
-        e.stopPropagation();
-    });
-
-    $('ul.topmenu input[type=search]').keyup(function(e) {
-        if (e.which == 27) {
-            $(this).blur();
-            $(this).parents('li').removeClass("opened");
-        }
-    });
 
     // Jumping through charts
     if ($('#chart-labels').length) {

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -5,6 +5,7 @@ window.Mousetrap = require('mousetrap');
 require('mousetrap/plugins/bind-dictionary/mousetrap-bind-dictionary');
 
 require('./charts');
+var clipboard = require('./clipboard');
 var filters = require('./filters');
 var journal = require('./journal');
 var treeTable = require('./tree-table');
@@ -26,6 +27,11 @@ $(document).ready(function() {
     // Journal
     if ($('#journal-table').length) {
         journal.initJournal();
+    };
+
+    // Clipboard on statistics page
+    if ($('#copy-balances').length) {
+        clipboard.initClipboard();
     };
 
     // Keyboard shortcuts

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -4,7 +4,7 @@ require('jquery-stupid-table/stupidtable');
 window.Mousetrap = require('mousetrap');
 require('mousetrap/plugins/bind-dictionary/mousetrap-bind-dictionary');
 
-require('./charts');
+var charts = require('./charts');
 var clipboard = require('./clipboard');
 var filters = require('./filters');
 var journal = require('./journal');
@@ -22,6 +22,11 @@ $(document).ready(function() {
     // Tree-expanding
     if ($('table.tree-table').length) {
         treeTable.initTreeTable();
+    };
+
+    // Charts
+    if ($('#chart-container').length) {
+        charts.initCharts();
     };
 
     // Journal

--- a/fava/static/sass/_chartist.scss
+++ b/fava/static/sass/_chartist.scss
@@ -51,9 +51,10 @@ $ct-series-colors: (
                 color: rgba(0, 0, 0, 0.5);
             }
         }
+        label+label { border-left: 1px solid rgba(0, 0, 0, 0.4) }
     }
 
-    .charts-container {
+    .chart-container {
         position: relative;
         height: 240px;
 

--- a/fava/static/sass/styles.scss
+++ b/fava/static/sass/styles.scss
@@ -42,6 +42,7 @@ header {
     color: #fff;
     padding: 0 10px;
     height: 41px;
+    z-index: 2;
 
     .branding {
         img {
@@ -192,10 +193,16 @@ header {
 }
 
 .main {
-    // min-height set via JS
+    position:absolute;
+    width:100%;
+    margin-top:-41px;
+    padding-top:41px;
+    min-height:100%;
+    overflow:hidden;
 
     aside {
-        // min-height set via JS
+        padding-bottom: 100000px;
+        margin-bottom: -100000px;
         width: 200px;
         float: left;
         color: #dadad9;

--- a/fava/static/webpack.config.js
+++ b/fava/static/webpack.config.js
@@ -5,7 +5,6 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 module.exports = {
   entry: {
     'app': './javascript/main.js',
-    'clipboard': './javascript/clipboard.js',
     'editor': './javascript/editor.js',
     'styles': './sass/styles.scss'
   },

--- a/fava/templates/charts/_chart_skeleton.html
+++ b/fava/templates/charts/_chart_skeleton.html
@@ -1,11 +1,12 @@
+{% set show_charts = config.user.getboolean('charts-show') %}
 <div class="charts">
     <div class="chart-filter">
         <form>
-            <input type="submit" id="toggle-chart" value="{% if config.user.getboolean('charts-show') %}Hide{% else %}Show{% endif %} charts"{% if not config.user.getboolean('charts-show') %} class="hide-charts"{% endif %}>
+            <input type="submit" id="toggle-chart" value="{% if show_charts %}Hide{% else %}Show{% endif %} charts">
         </form>
     </div>
-    <div class="charts-container"{% if not config.user.getboolean('charts-show') %} style="display: none"{% endif %}>
+    <div id="chart-container" class="chart-container{% if not show_charts %} hidden{% endif %}">
         <div class="loading">Loading charts&hellip;</div>
     </div>
-    <div id="chart-labels" class="chart-labels"{% if not config.user.getboolean('charts-show') %} style="display: none"{% endif %}> </div>
+    <div id="chart-labels" class="chart-labels{% if not show_charts %} hidden{% endif %}"> </div>
 </div>

--- a/fava/templates/statistics.html
+++ b/fava/templates/statistics.html
@@ -3,10 +3,6 @@
 
 {% import '_account_macros.html' as account_macros %}
 
-{% block javascript %}
-    <script type="text/javascript" src="{{ url_for('static', filename='gen/clipboard.js') }}"></script>
-{% endblock %}
-
 {% block content %}
     <h1>Statistics</h1>
 


### PR DESCRIPTION
- I've modularized the JS code some more and removed the now unnecessary `clipboard` entrypoint. It's now decided in `main.js` what modules to run on page load. Only the editor is still separate.
- Caching some selectors and using ID selectors in a few more places to improve performance.
- I've removed the JS code that sets the sidebar height and implemented a CSS solution. This means no more "flicker" on page load and the sidebar height will adjust automatically to layout changes (like toggling in the journal)