### PR TITLE
Show basename for document names

### DIFF
--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -166,6 +166,9 @@ class BeancountReportAPI(object):
 
             entry = serialize_entry(posting)
 
+            if isinstance(posting, Document):
+                entry['basename'] = os.path.basename(entry['filename'])
+
             if with_change_and_balance:
                 if isinstance(posting, Balance):
                     entry['change'] = {}

--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -166,9 +166,6 @@ class BeancountReportAPI(object):
 
             entry = serialize_entry(posting)
 
-            if isinstance(posting, Document):
-                entry['basename'] = os.path.basename(entry['filename'])
-
             if with_change_and_balance:
                 if isinstance(posting, Balance):
                     entry['change'] = {}

--- a/fava/api/serialization.py
+++ b/fava/api/serialization.py
@@ -1,8 +1,9 @@
 import decimal
+import os
 from datetime import date, datetime
 
 from beancount.core import compare
-from beancount.core.data import Balance, Transaction
+from beancount.core.data import Balance, Document, Transaction
 from beancount.core.amount import Amount
 from beancount.core.position import Position
 from beancount.core.number import ZERO
@@ -54,6 +55,9 @@ def serialize_entry(entry):
     if isinstance(entry, Balance):
         if entry.diff_amount:
             new_entry['balance'] = entry.diff_amount + entry.amount
+
+    if isinstance(entry, Document):
+        new_entry['basename'] = os.path.basename(entry.filename)
 
     if isinstance(entry, Transaction):
         if entry.flag in transaction_types:

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -97,7 +97,7 @@
                     Pad {{ account_link(entry.account) }} from {{ account_link(entry.source_account) }}
                 {% endif %}
                 {% if type == 'document' %}
-                    Document for {{ account_link(entry.account) }}: <a href="{{ url_for('document', file_path=entry.filename) }}">{{ entry.filename }}</a>
+                    Document for {{ account_link(entry.account) }}: <a href="{{ url_for('document', file_path=entry.filename) }}">{{ entry.basename }}</a>
                 {% endif %}
                 {% if type == 'balance' %}
                     Balance {{ account_link(entry.account) }}


### PR DESCRIPTION
Originally the whole path (which can be very long, and often includes the full account name) was shown for documents. Show only the basename.

Unfortunately there doesn't seem to be a `Jinja` basename filter, so I added a field to the document entries in the API.