### PR TITLE
Fix decimal import

### DIFF
--- a/fava/api/serialization.py
+++ b/fava/api/serialization.py
@@ -1,9 +1,8 @@
-import decimal
 from datetime import date, datetime
 
 from beancount.core import compare
 from beancount.core.data import Transaction
-from beancount.core.amount import Amount
+from beancount.core.amount import Amount, decimal
 from beancount.core.position import Position
 from beancount.core.number import ZERO
 from flask.json import JSONEncoder


### PR DESCRIPTION
Some Linux distros do not ship cdecimal by default, and users have to explicitly install cdecimal module. Beancount detects this and will use `cdecimal.Decimal` instead of `decimal.Decimal`, this causes `isinstance(o, decimal.Decimal)` in `BeanJSONEncoder` to return `False`, thus raises `TypeError: Decimal('12.34') is not JSON serializable`.

Instead of import decimal or cdecimal directly, import from beancount.core.amount solves this issue. This will import the proper decimal implemention detected by Beancount.