### PR TITLE
filter: make list more compact, clean up template

### DIFF
--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -21,7 +21,7 @@ optimize for performance at all.
 
 import operator
 import os
-from datetime import date, timedelta
+from datetime import date
 
 from beancount import loader
 from beancount.core import compare, getters, realization, inventory
@@ -32,7 +32,6 @@ from beancount.core.account_types import get_account_sign
 from beancount.core.data import (get_entry, iter_entry_dates, posting_sortkey,
                                  Open, Close, Note, Document, Balance,
                                  Transaction, Event, Query)
-from beancount.core.number import ZERO
 from beancount.ops import prices, holdings, summarize
 from beancount.parser import options
 from beancount.query import query
@@ -156,16 +155,12 @@ class BeancountReportAPI(object):
         in rendering tables.
         """
         return [{
-            'account': real_account.account,
-            'balances_children': self._total_balance(real_account),
-            'balances': serialize_inventory(real_account.balance, at_cost=True),
-            'is_leaf': len(real_account) == 0 or real_account.txn_postings,
-            'postings_count': len(real_account.txn_postings)
-        } for real_account in realization.iter_children(real_account)]
-
-    def _total_balance(self, real_account):
-        """Computes the total balance for real_account and its children."""
-        return serialize_inventory(realization.compute_balance(real_account), at_cost=True)
+            'account': ra.account,
+            'balances_children': serialize_inventory(realization.compute_balance(ra), at_cost=True),
+            'balances': serialize_inventory(ra.balance, at_cost=True),
+            'is_leaf': len(ra) == 0 or bool(ra.txn_postings),
+            'postings_count': len(ra.txn_postings)
+        } for ra in realization.iter_children(real_account)]
 
     def _journal(self, postings, include_types=None, with_change_and_balance=False):
         journal = []

--- a/fava/static/sass/_filter.scss
+++ b/fava/static/sass/_filter.scss
@@ -15,26 +15,13 @@ div.filter {
     top: 41px;
 
     & > ul {
-        max-height: 240px;
+        max-height: 400px;
         overflow-y: auto;
 
-        & > li.info {
-            padding: 3px 10px;
-            color: lighten($color_text, 60);
-            line-height: 1.3em;
-
+        li {
             a {
-                color: lighten($color_text, 40);
-                text-decoration: underline;
-            }
-        }
-
-        li.suggestion {
-            a {
-                padding-right: 20px !important;
                 display: block;
-                line-height: 1;
-                padding: 8px 10px;
+                padding: 5px 10px;
                 color: $color_links !important;
             }
 
@@ -51,18 +38,15 @@ div.filter {
         }
     }
 
-    div.inputcontainer {
-        margin: 10px;
-
-        input {
-            height: 26px;
-            display: block;
-            border: 1px solid lighten($color_text, 80);
-            border-radius: 5px;
-            line-height: 26px;
-            width: 100%;
-            font-size: 13px;
-            font-family: $font_family;
-        }
+    input {
+        margin: 5px 10px;
+        height: 26px;
+        display: block;
+        border: 1px solid lighten($color_text, 80);
+        border-radius: 5px;
+        line-height: 26px;
+        width: 380px;
+        font-size: 13px;
+        font-family: $font_family;
     }
 }

--- a/fava/templates/_entry_filters.html
+++ b/fava/templates/_entry_filters.html
@@ -1,33 +1,26 @@
+{% set time_filter = g.filters['time'] %}
+{% set tag_filter = g.filters['tag'] %}
+{% set account_filter = g.filters['account'] %}
+{% set payee_filter = g.filters['payee'] %}
 <form id="filter-form" action="{{ url_for_current() }}" method="GET">
     <ul class="topmenu">
-        {% set time_search_phrases = ['This Month', '2015-03', 'March 2015', 'Mar 2015', 'Last Year', 'Aug Last Year', '2010-10 - 2014', 'Year to Date' ] %}
-        <li{% if g.filters['time'] %} class="selected"{% endif %}>
+        <li{% if time_filter %} class="selected"{% endif %}>
             <a href="{{ url_for_current(time=None) }}">
-                <span>{{ g.filters['time'] or 'Time' }}</span>
+                {{ time_filter or 'Time' }}
             </a>
             <div class="filter" id="filter-time">
-                <div class="inputcontainer">
-                    <input type="search">
-                </div>
+                <input type="search">
                 <ul>
-                    <li class="info">Supports search strings like
-                        {% for suggestion in time_search_phrases %}
-                            {% if suggestion != g.filters['time'] %}
-                            <a href="{{ url_for_current(time=suggestion) }}" data-filter="{{ suggestion }}">{{ suggestion }}</a>{% if not loop.last %}, {% endif %}
-                            {% endif %}
-                        {% endfor %}
-                    </li>
-
-                    {% if g.filters['time'] and g.filters['time'] not in api.active_years|map('string') %}
-                        <li class="suggestion selected" data-filter="{{ g.filters['time'] }}">
-                            <a href="{{ url_for_current(time=None) }}">{{ g.filters['time'] }}</a>
+                    {% if time_filter and time_filter|int not in api.active_years %}
+                        <li class="selected" data-filter="{{ time_filter }}">
+                            <a href="{{ url_for_current(time=None) }}">{{ time_filter }}</a>
                         </li>
                     {% endif %}
 
                     {% for time_ in api.active_years %}
-                    <li class="suggestion{% if time_|string == g.filters['time'] %} selected{% endif %}" data-filter="{{ time_ }}">
-                        {% if time_|string == g.filters['time'] %}
-                            <a href="{{ url_for_current(time=None) }}">{{ g.filters['time'] }}</a>
+                    <li {% if time_|string == time_filter %}class="selected{% endif %}" data-filter="{{ time_ }}">
+                        {% if time_|string == time_filter %}
+                            <a href="{{ url_for_current(time=None) }}">{{ time_filter }}</a>
                         {% else %}
                             <a href="{{ url_for_current(time=time_) }}">{{ time_ }}</a>
                         {% endif %}
@@ -36,101 +29,82 @@
                 </ul>
             </div>
         </li>
-        <li{% if g.filters['tag']  %} class="selected"{% endif %}>
+        <li{% if tag_filter  %} class="selected"{% endif %}>
             <a href="{{ url_for_current(tag=[]) }}">
-                <span>
-                    {% if g.filters['tag'] %}
-                        {% if g.filters['tag']|length == 1 %}
-                            # {{ g.filters['tag']|first }}
-                        {% else %}
-                            Multiple tags
-                        {% endif %}
+                {% if tag_filter %}
+                    {% if tag_filter|length == 1 %}
+                        # {{ tag_filter|first }}
                     {% else %}
-                        Tag
+                        Multiple tags
                     {% endif %}
-                </span>
+                {% else %}
+                    Tag
+                {% endif %}
             </a>
             <div class="filter">
-                <div class="inputcontainer">
-                    <input type="search">
-                </div>
+                <input type="search">
                 <ul>
-                    <li class="info">You can select multiple tags.</li>
-
-                    {% for tag in g.filters['tag'] %}
-                    <li class="suggestion selected" data-filter="{{ tag|lower }}">
+                {% for tag in tag_filter %}
+                    <li class="selected" data-filter="{{ tag|lower }}">
                         <a href="{{ url_for_current(pop=('tag',tag)) }}">{{ tag }}</a>
                     </li>
-                    {% endfor %}
+                {% endfor %}
 
-                {% for tag in api.active_tags %}
-                    {% if tag not in g.filters['tag'] %}
-                    <li class="suggestion" data-filter="{{ tag|lower }}">
-                        <a href="{{ url_for_current(tag=[tag]+g.filters['tag']) }}"># {{ tag }}</a>
+                {% for tag in api.active_tags if tag not in tag_filter %}
+                    <li data-filter="{{ tag|lower }}">
+                        <a href="{{ url_for_current(tag=[tag]+tag_filter) }}"># {{ tag }}</a>
                     </li>
-                    {% endif %}
                 {% endfor %}
                 </ul>
             </div>
         </li>
-        <li{% if g.filters['account'] %} class="selected"{% endif %}>
+        <li{% if account_filter %} class="selected"{% endif %}>
             <a href="{{ url_for_current(account=None) }}">
-                <span>{{ g.filters['account'] or 'Account' }}</span>
+                {{ account_filter or 'Account' }}
             </a>
             <div class="filter">
-                <div class="inputcontainer">
-                    <input type="search">
-                </div>
+                <input type="search">
                 <ul>
-                    {% if g.filters['account'] %}
-                        <li class="suggestion selected" data-filter="{{ g.filters['account']|lower }}">
-                            <a href="{{ url_for_current(account=None) }}" title="{{ g.filters['account'] }}">{{ g.filters['account'] }}</a>
-                        </li>
+                    {% if account_filter %}
+                    <li class="selected" data-filter="{{ account_filter|lower }}">
+                        <a href="{{ url_for_current(account=None) }}" title="{{ account_filter }}">{{ account_filter }}</a>
+                    </li>
                     {% endif %}
                     {% for account in api.all_accounts %}
-                    <li class="suggestion{% if account == g.filters['account'] %} selected{% endif %}" data-filter="{{ account|lower }}">
+                    <li {% if account == account_filter %}class="selected{% endif %}" data-filter="{{ account|lower }}">
                         <a href="{{ url_for_current(account=account) }}" title="{{ account }}">
-                            {% for i in range(account|account_level) %}&ndash;{% endfor %}&nbsp;{{ account|last_segment }}
+                            {{ "–" * account|account_level }}&nbsp;{{ account|last_segment }}
                         </a>
                     </li>
                     {% endfor %}
                 </ul>
             </div>
         </li>
-        <li{% if g.filters['payee']  %} class="selected"{% endif %}>
+        <li{% if payee_filter  %} class="selected"{% endif %}>
         {% macro print_payee(payee) %}{% if payee %}{{ payee }}{% else %}<em>{{ 'No payee' }}</em>{% endif %}{% endmacro %}
             <a href="{{ url_for_current(payee=[]) }}">
-                <span>
-                    {% if g.filters['payee'] %}
-                        {% if g.filters['payee']|length == 1 %}
-                            {{ print_payee(g.filters['payee']|first) }}
-                        {% else %}
-                            Multiple payees
-                        {% endif %}
+                {% if payee_filter %}
+                    {% if payee_filter|length == 1 %}
+                        {{ print_payee(payee_filter|first) }}
                     {% else %}
-                        Payee
+                        Multiple payees
                     {% endif %}
-                </span>
+                {% else %}
+                    Payee
+                {% endif %}
             </a>
             <div class="filter">
-                <div class="inputcontainer">
-                    <input type="search">
-                </div>
+                <input type="search">
                 <ul>
-                    <li class="info">You can select multiple payees.</li>
-
-                    {% for payee in g.filters['payee'] %}
-                    <li class="suggestion selected" data-filter="{{ payee|lower }}">
+                {% for payee in payee_filter %}
+                    <li class="selected" data-filter="{{ payee|lower }}">
                         <a href="{{ url_for_current(pop=('payee', payee)) }}">{{ print_payee(payee) }}</a>
                     </li>
-                    {% endfor %}
-
-                {% for payee in api.active_payees %}
-                    {% if payee not in g.filters['payee'] %}
-                    <li class="suggestion" data-filter="{{ payee|lower }}">
-                        <a href="{{ url_for_current(payee=[payee]+g.filters['payee']) }}">{{ print_payee(payee) }}</a>
+                {% endfor %}
+                {% for payee in api.active_payees if payee not in payee_filter %}
+                    <li data-filter="{{ payee|lower }}">
+                        <a href="{{ url_for_current(payee=[payee]+payee_filter) }}">{{ print_payee(payee) }}</a>
                     </li>
-                    {% endif %}
                 {% endfor %}
                 </ul>
             </div>


### PR DESCRIPTION
I've removed the suggestions from the filter lists, they're nice to have on first use maybe but just take up space afterwards. And now we have the help page to get new users started.

I've also decreased the padding between the filter suggestions, before the list was just endless with a lot of payees or accounts.