### PR TITLE
Downloads: Correct sheet order

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -2,6 +2,7 @@
 import configparser
 import os
 from datetime import datetime
+from collections import OrderedDict
 import io
 
 import markdown2
@@ -173,10 +174,10 @@ def query(bql=None, query_hash=None, result_format='html'):
                 result_array = [[error]]
 
             if result_format in ('xls', 'xlsx', 'ods'):
-                book = pyexcel.Book({
-                    'Results': result_array,
-                    'Query':   [['Query'],[query]]
-                })
+                book = pyexcel.Book(OrderedDict([
+                    ('Results', result_array),
+                    ('Query',   [['Query'],[query]])
+                ]))
                 respIO = io.BytesIO()
                 book.save_to_memory(result_format, respIO)
             else:


### PR DESCRIPTION
Problem:
In the downloads for XLS, XLSX and ODS the "Query" is the first
sheet, "Results" the second. This is confusing.

Root cause:
When constructing the `pyexcel.Book` a `dict` is provided with
the required sheets. A dict is unordered, as as result, the
Sheets are added in alphabetical order to the Book.

Solution:
Use an OrderedDict, so the correct ordering is maintained.