### PR TITLE
Ignore filters in Custom Query

### DIFF
--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -547,7 +547,7 @@ class BeancountReportAPI(object):
         return is_present
 
     def query(self, bql_query_string, numberify=False):
-        return query.run_query(self.entries, self.options, bql_query_string, numberify=numberify)
+        return query.run_query(self.all_entries, self.options, bql_query_string, numberify=numberify)
 
     def _last_posting_for_account(self, account_name):
         """


### PR DESCRIPTION
Problem:
When a filter (e.g. Time Filter) is in use, this affects Custom
Queries as well.

Root cause:
When executing a Query, `entries` is used, which contains the
entries after filters have been applied.

Solution:
Use `all_entries` instead.