### PR TITLE
Sidebar: highlight selected Custom Query

### DIFF
--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -268,6 +268,10 @@ div.main {
                     padding: 0;
 
                     li {
+                        &.selected, a:hover {
+                            background-color: darken($color_sidebar_background, 15);
+                        }
+
                         font-size: 0.95em;
                         line-height: 0.95em;
 

--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -93,7 +93,7 @@
                     {% if id == "query" and user_queries|length > 0 %}
                         <ul class="navigation">
                         {% for query in user_queries %}
-                            <li><a href="{{ url_for('get_stored_query', stored_query_hash=query.hash) }}">{{ query.name|truncate(25, True, ' …') }}</a></li>
+                            <li{% if query.hash == query_hash %} class="selected"{% endif %}><a href="{{ url_for('get_stored_query', stored_query_hash=query.hash) }}">{{ query.name|truncate(25, True, ' …') }}</a></li>
                         {% endfor %}
                         </ul>
                     {% endif %}


### PR DESCRIPTION
Problem:
When selecting a specific `Custom Query`, the whole block is
highlighted.

Root cause:
Highlighting is done based on the current page. All specific
queries are part of the same `Custom Query` page.

Solution:
Add another level of highlighting, based on the query-hash.