### PR TITLE
Add metadata to postings (#184)

### DIFF
--- a/fava/api/serialization.py
+++ b/fava/api/serialization.py
@@ -36,19 +36,7 @@ transaction_types = {
 
 def serialize_entry(entry):
     new_entry = entry._asdict()
-    new_entry['meta'] = {
-        'type': entry.__class__.__name__.lower(),
-        'filename': entry.meta['filename'],
-        'lineno': entry.meta['lineno'],
-    }
-    new_entry.update({
-        'hash': compare.hash_entry(entry),
-        'metadata': entry.meta.copy()
-    })
-
-    new_entry['metadata'].pop("__tolerances__", None)
-    new_entry['metadata'].pop("filename", None)
-    new_entry['metadata'].pop("lineno", None)
+    _add_metadata(new_entry, entry)
 
     if isinstance(entry, Transaction):
         if entry.flag in transaction_types:
@@ -71,6 +59,24 @@ def serialize_inventory(inventory, at_cost=False):
         inventory = inventory.units()
     return {p.units.currency: p.units.number for p in inventory if p.units.number != ZERO}
 
-
 def serialize_posting(posting):
-    return posting._asdict()
+    new_posting = posting._asdict()
+    _add_metadata(new_posting, posting)
+    return new_posting
+
+def _add_metadata(new_entry, entry):
+    new_entry['meta'] = {
+        'type': entry.__class__.__name__.lower(),
+        'filename': entry.meta['filename'],
+        'lineno': entry.meta['lineno'],
+    }
+    new_entry.update({
+        'hash': compare.hash_entry(entry),
+        'metadata': entry.meta.copy()
+    })
+
+    new_entry['metadata'].pop("__tolerances__", None)
+    new_entry['metadata'].pop("filename", None)
+    new_entry['metadata'].pop("lineno", None)
+
+    return new_entry

--- a/fava/api/serialization.py
+++ b/fava/api/serialization.py
@@ -67,16 +67,16 @@ def serialize_posting(posting):
 def _add_metadata(new_entry, entry):
     new_entry['meta'] = {
         'type': entry.__class__.__name__.lower(),
-        'filename': entry.meta['filename'],
-        'lineno': entry.meta['lineno'],
     }
-    new_entry.update({
-        'hash': compare.hash_entry(entry),
-        'metadata': entry.meta.copy()
-    })
+    new_entry['hash'] = compare.hash_entry(entry)
 
-    new_entry['metadata'].pop("__tolerances__", None)
-    new_entry['metadata'].pop("filename", None)
-    new_entry['metadata'].pop("lineno", None)
+    if entry.meta:
+        new_entry['meta']['filename'] = entry.meta['filename']
+        new_entry['meta']['lineno'] = entry.meta['lineno']
+
+        new_entry['metadata'] = entry.meta.copy()
+        new_entry['metadata'].pop("__tolerances__", None)
+        new_entry['metadata'].pop("filename", None)
+        new_entry['metadata'].pop("lineno", None)
 
     return new_entry

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -144,6 +144,18 @@
                 <span class="balance num"></span>
                 {% endif %}
             </p>
+             {% if posting.metadata %}
+                 <dl class="metadata{% if not show_metadata %} hidden{% endif %}">
+                     {% for key, value in posting.metadata.items() %}
+                         <dt>{{ key }}</dt>
+                         <dd>
+                             {%- if key == 'statement' %}<a href="{{ url_for('document', file_path=value)  }}">{% endif -%}
+                             {{ value }}
+                             {%- if key == 'statement' %}</a>{% endif -%}
+                         </dd>
+                     {% endfor %}
+                 </dl>
+             {% endif %}
         </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
Metadata can not only be attached to transactions, but also to
individual postings in transactions.

Add metadata in serialization of postings, and display it in the
journal view.