### PR TITLE
URL parameter error in Custom Query (#181)

### DIFF
--- a/fava/static/javascript/editor.js
+++ b/fava/static/javascript/editor.js
@@ -62,7 +62,8 @@ $(document).ready(function() {
             event.stopImmediatePropagation();
             var $button = $(this);
             $button.attr('disabled', 'disabled').attr('value', 'Submitting query...');
-            var nextUrl = $button.parents('form').attr('action') + "?bql=" + encodeURIComponent(editor.getValue());
+            var nextUrl = $button.parents('form').attr('action');
+            nextUrl = nextUrl + (nextUrl.split('?')[1] ? '&' : '?') + "bql=" + encodeURIComponent(editor.getValue());
             var storedQuerySelectedIndex = $('.stored-queries select').prop('selectedIndex');
             if (storedQuerySelectedIndex > 0) {
                 var storedQueryHash = $('.stored-queries select option:nth-child(' + (storedQuerySelectedIndex + 1) + ')').attr('data-stored-query-hash');


### PR DESCRIPTION
Doing a custom query after a time range is selected leads to URL parameter error:
```
http://localhost:5000/query/?time=2016?bql=balances%20from%20year%20%3D%202015%3B
```
The second ? should be &.

Root cause:
The code to construct the redirect URL hardcodes the `?`.

Solution:
Check for the existance of a `?` in the URL. If it exists, use `&` instead.