### PR TITLE
Click

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -44,8 +44,19 @@ def load_settings():
 
     for option in config.bool_options:
         app.config[option] = app.config.raw.getboolean('fava', option)
-
-    app.config.user = app.config.raw['fava']
+    for option in config.int_options:
+        app.config[option] = app.config.raw.getint('fava', option)
+    for option in config.list_options:
+        if app.config.raw.has_option('fava', option):
+            app.config[option] = \
+                app.config.get('fava', option).strip().split("\n")
+        else:
+            app.config[option] = None
+    for option in config.str_options:
+        if app.config.raw.has_option('fava', option):
+            app.config[option] = app.config.raw.get('fava', option)
+        else:
+            app.config[option] = None
 
 
 def list_help_pages():
@@ -342,15 +353,11 @@ def template_context():
         else:
             return False
 
-    if 'collapse-accounts' in app.config.user:
-        collapse_accounts = \
-            app.config.user['collapse-accounts'].strip().split("\n")
-
     def should_collapse_account(account_name):
-        if 'collapse-accounts' not in app.config.user:
+        if not app.config['collapse-accounts']:
             return False
 
-        return account_name in collapse_accounts
+        return account_name in app.config['collapse_accounts']
 
     return dict(url_for_current=url_for_current,
                 url_for_source=url_for_source,
@@ -361,7 +368,7 @@ def template_context():
                 operating_currencies=app.api.options['operating_currency'],
                 today=datetime.now().strftime('%Y-%m-%d'),
                 interval=request.args.get('interval',
-                                          app.config.user['default-interval']))
+                                          app.config['default-interval']))
 
 
 def uniquify(seq):

--- a/fava/application.py
+++ b/fava/application.py
@@ -326,6 +326,23 @@ def basename(file_path):
     return os.path.basename(file_path)
 
 
+@app.template_filter()
+def should_collapse_account(account_name):
+    if not app.config['collapse-accounts']:
+        return False
+
+    return account_name in app.config['collapse_accounts']
+
+
+@app.template_filter()
+def uptodate_eligible(account_name):
+    key = 'fava-uptodate-indication'
+    if key in app.api.account_open_metadata(account_name):
+        return app.api.account_open_metadata(account_name)[key] == 'True'
+    else:
+        return False
+
+
 @app.context_processor
 def template_context():
     def url_for_current(**kwargs):
@@ -346,23 +363,8 @@ def template_context():
         else:
             return url_for('source', **args)
 
-    def uptodate_eligible(account_name):
-        key = 'fava-uptodate-indication'
-        if key in app.api.account_open_metadata(account_name):
-            return app.api.account_open_metadata(account_name)[key] == 'True'
-        else:
-            return False
-
-    def should_collapse_account(account_name):
-        if not app.config['collapse-accounts']:
-            return False
-
-        return account_name in app.config['collapse_accounts']
-
     return dict(url_for_current=url_for_current,
                 url_for_source=url_for_source,
-                uptodate_eligible=uptodate_eligible,
-                should_collapse_account=should_collapse_account,
                 api=app.api,
                 options=app.api.options,
                 operating_currencies=app.api.options['operating_currency'],

--- a/fava/cli.py
+++ b/fava/cli.py
@@ -1,109 +1,68 @@
 # -*- coding: utf-8 -*-
-import argparse
 import os
-import sys
 import errno
 
+import click
 from livereload import Server
 
 from fava.application import app, load_settings
 
 
-def run(argv):
-    parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+@click.command()
+@click.argument('filename', type=click.Path(exists=True))
+@click.option('-p', '--port', type=int, default=5000,
+              help='The port to listen on. (default: 5000)')
+@click.option('-H', '--host', type=str, default='localhost',
+              help='The host to listen on. (default: localhost)')
+@click.option('-s', '--settings',
+              type=click.Path(exists=True, resolve_path=True),
+              help='Settings file for fava.')
+@click.option('-d', '--debug', is_flag=True,
+              help='Turn on debugging. Disables live-reloading.')
+@click.option('--profile', is_flag=True,
+              help='Turn on profiling. Implies --debug.')
+@click.option('--profile-dir', type=click.Path(),
+              help='Output directory for profiling data.')
+@click.option('--profile-restriction', type=int, default=30,
+              help='Number of functions to show in profile.')
+def main(filename, port, host, settings, debug, profile, profile_dir,
+         profile_restriction):
+    """Start fava for FILENAME on http://host:port."""
 
-    parser.add_argument('-p', '--port',
-                        action='store',
-                        type=int,
-                        default=5000,
-                        help="Port to listen on.")
+    if profile_dir:
+        profile = True
+    if profile:
+        debug = True
 
-    parser.add_argument('-H', '--host',
-                        action='store',
-                        type=str,
-                        default='localhost',
-                        help="Host for the webserver.")
+    app.beancount_file = filename
 
-    parser.add_argument('-s', '--settings',
-                        action='store',
-                        type=str,
-                        help="Settings-file for fava.")
-
-    parser.add_argument('-d', '--debug',
-                        action='store_true',
-                        help="Turn on debugging. This uses the built-in Flask"
-                             "webserver, and live-reloading of beancount-files"
-                             "is disabled.")
-
-    parser.add_argument('--profile',
-                        action='store_true',
-                        help="Turn on profiling.  Implies --debug.  Profiling"
-                             "information for each request will be printed to"
-                             "the log, unless --pstats-output is also"
-                             "specified.")
-
-    parser.add_argument('--pstats-output',
-                        type=str,
-                        help="Output directory for profiling pstats data.  \
-                              Implies --profile.  If this is specified, \
-                              profiling information will be saved to the \
-                              specified directly and will not be printed to \
-                              the log.")
-
-    parser.add_argument('--profile-restriction',
-                        type=int,
-                        default=30,
-                        help='Maximum number of functions to show in profile printed \
-                              to the log.')
-
-    parser.add_argument('filename',
-                        type=str,
-                        help="Beancount input file.")
-
-    args = parser.parse_args(argv)
-
-    if args.pstats_output is not None:
-        args.profile = True
-    if args.profile:
-        args.debug = True
-
-    app.beancount_file = args.filename
-
-    if args.debug:
+    if debug:
         app.api.load_file(app.beancount_file)
-        if args.settings:
-            load_settings(os.path.realpath(args.settings))
+        if settings:
+            load_settings(settings)
 
-        if args.profile:
+        if profile:
             from werkzeug.contrib.profiler import ProfilerMiddleware
             app.config['PROFILE'] = True
-            kwargs = {}
-            if args.pstats_output is not None:
-                kwargs['profile_dir'] = args.pstats_output
             app.wsgi_app = ProfilerMiddleware(
                 app.wsgi_app,
-                restrictions=[args.profile_restriction], **kwargs)
+                restrictions=(profile_restriction),
+                profile_dir=profile_dir if profile_dir else None)
 
-        app.config['ASSETS_CACHE'] = True
-        app.config['ASSETS_DEBUG'] = True
-
-        app.run(args.host, args.port, args.debug)
+        app.run(host, port, debug)
     else:
         server = Server(app.wsgi_app)
         reload_source_files(server)
-        if args.settings:
-            reload_settings(server, os.path.realpath(args.settings))
+        if settings:
+            reload_settings(server, settings)
 
         try:
-            server.serve(port=args.port, host=args.host, debug=args.debug)
+            server.serve(port=port, host=host, debug=debug)
         except OSError as e:
             if e.errno == errno.EADDRINUSE:
                 print("Error: Can not start webserver because the port/address"
                       "is already in use.")
-                print("Please choose another port with the '-p' option."
-                      "({})".format(e))
+                print("Please choose another port with the '-p' option.")
             else:
                 raise
         except:
@@ -126,10 +85,3 @@ def reload_settings(server, settings_path):
     """Auto-reload the settings-file."""
     load_settings(settings_path)
     server.watch(settings_path, lambda: reload_settings(server, settings_path))
-
-
-def main():
-    run(sys.argv[1:])
-
-if __name__ == '__main__':
-    main()

--- a/fava/cli.py
+++ b/fava/cli.py
@@ -5,7 +5,7 @@ import errno
 import click
 from livereload import Server
 
-from fava.application import app, load_file, load_settings
+from fava.application import api, app, load_file, load_settings
 
 
 @click.command()
@@ -58,8 +58,7 @@ def main(filename, port, host, settings, debug, profile, profile_dir,
         def reload_source_files():
             load_file()
             include_path = os.path.dirname(app.config['BEANCOUNT_FILE'])
-            for filename in app.api.options['include'] + \
-                    app.api.options['documents']:
+            for filename in api.options['include'] + api.options['documents']:
                 server.watch(os.path.join(include_path, filename),
                              reload_source_files)
         reload_source_files()

--- a/fava/config.py
+++ b/fava/config.py
@@ -1,0 +1,44 @@
+bool_options = [
+    'journal-show-legs',
+    'journal-show-metadata',
+    'journal-show-childentries',
+    'journal-show-type-open',
+    'journal-show-type-close',
+    'journal-show-type-transaction',
+    'journal-show-type-balance',
+    'journal-show-type-note',
+    'journal-show-type-document',
+    'journal-show-type-pad',
+    'journal-show-type-query',
+    'journal-show-transaction-cleared',
+    'journal-show-transaction-pending',
+    'journal-show-transaction-padding',
+    'journal-show-transaction-summarize',
+    'journal-show-transaction-transfer',
+    'journal-show-transaction-other',
+    'journal-general-show-balances',
+    'treemaps-show-negative-numbers',
+    'charts-show',
+    'uptodate-indicator-show-everywhere',
+    'editor-strip-trailing-whitespace',
+    'use-external-editor',
+    'show-closed-accounts',
+    'show-accounts-with-zero-balance',
+    'show-accounts-with-zero-transactions',
+]
+
+int_options = [
+    'uptodate-indicator-grey-lookback-days',
+    'sidebar-show-queries',
+    'editor-print-margin-column',
+]
+
+list_options = [
+    'collapse-accounts',
+]
+
+str_options = [
+    'theme',
+    'default-interval',
+    'editor-insert-marker',
+]

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -1,26 +1,26 @@
 {% set entry_types = ['open', 'close', 'transaction', 'balance', 'note', 'document', 'pad', 'query'] %}
 {% set transaction_types = ['cleared', 'pending', 'padding', 'summarize', 'transfer', 'other'] %}
 {% set show_type = {
-    'open':        config.user.getboolean('journal-show-type-open'),
-    'close':       config.user.getboolean('journal-show-type-close'),
-    'transaction': config.user.getboolean('journal-show-type-transaction'),
-    'balance':     config.user.getboolean('journal-show-type-balance'),
-    'note':        config.user.getboolean('journal-show-type-note'),
-    'document':    config.user.getboolean('journal-show-type-document'),
-    'pad':         config.user.getboolean('journal-show-type-pad'),
-    'query':       config.user.getboolean('journal-show-type-query')
+    'open':        config['journal-show-type-open'],
+    'close':       config['journal-show-type-close'],
+    'transaction': config['journal-show-type-transaction'],
+    'balance':     config['journal-show-type-balance'],
+    'note':        config['journal-show-type-note'],
+    'document':    config['journal-show-type-document'],
+    'pad':         config['journal-show-type-pad'],
+    'query':       config['journal-show-type-query']
 } %}
 {% set show_transaction_type = {
-    'cleared':   config.user.getboolean('journal-show-transaction-cleared'),
-    'pending':   config.user.getboolean('journal-show-transaction-pending'),
-    'padding':   config.user.getboolean('journal-show-transaction-padding'),
-    'summarize': config.user.getboolean('journal-show-transaction-summarize'),
-    'transfer':  config.user.getboolean('journal-show-transaction-transfer'),
-    'other':     config.user.getboolean('journal-show-transaction-other'),
+    'cleared':   config['journal-show-transaction-cleared'],
+    'pending':   config['journal-show-transaction-pending'],
+    'padding':   config['journal-show-transaction-padding'],
+    'summarize': config['journal-show-transaction-summarize'],
+    'transfer':  config['journal-show-transaction-transfer'],
+    'other':     config['journal-show-transaction-other'],
 } %}
 
-{% set show_metadata = config.user.getboolean('journal-show-metadata') %}
-{% set show_legs = config.user.getboolean('journal-show-legs') %}
+{% set show_metadata = config['journal-show-metadata'] %}
+{% set show_legs = config['journal-show-legs'] %}
 
 {% if show_tablefilter %}
     <div id="entry-filters" class="table-filter">

--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -43,13 +43,13 @@
 } %}
 {% set active_page = active_page|default('journal') %}
 {% set show_filters = show_filters|default(True) %}
-{% set user_queries = api.queries()[:config.user.getint('sidebar-show-queries')] %}
+{% set user_queries = api.queries()[:config['sidebar-show-queries']] %}
 <!doctype html>
 <html>
 <head>
     {% block head %}
     <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='gen/theme_' + config.user.get('theme') + '.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='gen/theme_' + config['theme'] + '.css') }}">
     <title>{% block title %}{{ all_pages[active_page] }}{% endblock %} - {{ api.title }}</title>
     {% endblock %}
     <script>window.chartData = [];</script>

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -18,7 +18,7 @@
         {% for account in real_accounts recursive %}
             {% if account|show_account %}
             {% with account_level = loop.depth %}
-            <tr data-level="{{ account_level }}" data-is-parent="{% if not account.is_leaf %}true{% else %}false{% endif %}"{% if should_collapse_account(account.account) %} class="hides"{% endif %}>
+            <tr data-level="{{ account_level }}" data-is-parent="{% if not account.is_leaf %}true{% else %}false{% endif %}"{% if account.account|should_collapse_account %} class="hides"{% endif %}>
                 <td class="account account-level-{{ account_level }} droptarget" data-level="{{ account_level }}" data-account-name="{{ account.account }}">
                     {{ account_macros.account_name(account.account, last_segment=True) }}
                 </td>

--- a/fava/templates/account.html
+++ b/fava/templates/account.html
@@ -30,7 +30,7 @@
     </div>
 
     {% if journal %}
-        {% set journal = api.journal(account_name, with_change_and_balance=True, with_journal_children=config.user.getboolean('journal-show-childentries')) %}
+        {% set journal = api.journal(account_name, with_change_and_balance=True, with_journal_children=config['journal-show-childentries']) %}
         {% with show_tablefilter=True, show_change_and_balance=True %}
             {% include "_journal_table.html" %}
         {% endwith %}

--- a/fava/templates/charts/_chart_skeleton.html
+++ b/fava/templates/charts/_chart_skeleton.html
@@ -1,6 +1,6 @@
 {% import 'macros/_interval_macros.html' as interval_macros with context %}
 
-{% set show_charts = config.user.getboolean('charts-show') %}
+{% set show_charts = config['charts-show'] %}
 <div class="charts">
     <div class="chart-filter">
         <form>

--- a/fava/templates/charts/_charts.html
+++ b/fava/templates/charts/_charts.html
@@ -15,7 +15,7 @@ window.chartData.push({
         {% for account in treemap_data.balances recursive %}
             {% if account.is_leaf and currency in account.balance %}
                 {% set value = account.balance[currency] * (treemap_data.modifier or 1) %}
-                {% if value >= 0 or config.user.getboolean('treemaps-show-negative-numbers') %}
+                {% if value >= 0 or config['treemaps-show-negative-numbers'] %}
                 {
                     {% if value < 0 %}
                     label: '<a href="{{ url_for("account_with_journal", name=account.account) }}"><em>({{ account.account|last_segment }})</em></a>',

--- a/fava/templates/javascript/_editor.html
+++ b/fava/templates/javascript/_editor.html
@@ -3,7 +3,7 @@
     window.allCommodities = {{ options['commodities']|tojson|safe }};
     window.allTags = {{ api.active_tags|tojson|safe }};
 
-    window.editorStripTrailingWhitespace = {{ config.user.getboolean('editor-strip-trailing-whitespace')|tojson|safe }};
+    window.editorStripTrailingWhitespace = {{ config['editor-strip-trailing-whitespace']|tojson|safe }};
     {% if config.user.get('editor-insert-marker') %}
         window.editorInsertMarker = "{{ config.user.get('editor-insert-marker') }}";
     {% endif %}

--- a/fava/templates/javascript/_editor.html
+++ b/fava/templates/javascript/_editor.html
@@ -4,8 +4,8 @@
     window.allTags = {{ api.active_tags|tojson|safe }};
 
     window.editorStripTrailingWhitespace = {{ config['editor-strip-trailing-whitespace']|tojson|safe }};
-    {% if config.user.get('editor-insert-marker') %}
-        window.editorInsertMarker = "{{ config.user.get('editor-insert-marker') }}";
+    {% if config['editor-insert-marker'] %}
+        window.editorInsertMarker = "{{ config['editor-insert-marker'] }}";
     {% endif %}
 </script>
 <script type="text/javascript" src="{{ url_for('static', filename='gen/editor.js') }}"></script>

--- a/fava/templates/journal.html
+++ b/fava/templates/journal.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <h1>General Ledger</h1>
-    {% with journal = api.journal(), show_tablefilter=True, show_change_and_balance=config.user.getboolean('journal-general-show-balances')  %}
+    {% with journal = api.journal(), show_tablefilter=True, show_change_and_balance=config['journal-general-show-balances']  %}
         {% include "_journal_table.html" %}
     {% endwith %}
 {% endblock %}

--- a/fava/templates/macros/_account_macros.html
+++ b/fava/templates/macros/_account_macros.html
@@ -7,7 +7,7 @@
 
 {% macro indicator(account_name) %}
 {% if account_name and uptodate_eligible(account_name) %}
-    {% set status=api.is_account_uptodate(account_name, look_back_days=config.user.getint('uptodate-indicator-grey-lookback-days')) %}
+    {% set status=api.is_account_uptodate(account_name, look_back_days=config['uptodate-indicator-grey-lookback-days']) %}
     {% if status %}
         <span class="status-indicator status-{{ status }}" title="{{ infotext[status] }}"></span>
     {% endif %}
@@ -17,7 +17,7 @@
 {% macro last_account_activity(account_name) %}
 {% if account_name and uptodate_eligible(account_name) %}
 {% set last_account_activity_in_days=api.last_account_activity_in_days(account_name) %}
-{% if last_account_activity_in_days > config.user.getint('uptodate-indicator-grey-lookback-days') %}
+{% if last_account_activity_in_days > config['uptodate-indicator-grey-lookback-days'] %}
     <span class="status-indicator status-gray" title="{{ infotext['gray'] }} ({{ last_account_activity_in_days }} days ago)"></span>
 {% endif %}
 {% endif %}

--- a/fava/templates/macros/_account_macros.html
+++ b/fava/templates/macros/_account_macros.html
@@ -6,7 +6,7 @@
 } %}
 
 {% macro indicator(account_name) %}
-{% if account_name and uptodate_eligible(account_name) %}
+{% if account_name and account_name|uptodate_eligible %}
     {% set status=api.is_account_uptodate(account_name, look_back_days=config['uptodate-indicator-grey-lookback-days']) %}
     {% if status %}
         <span class="status-indicator status-{{ status }}" title="{{ infotext[status] }}"></span>
@@ -15,7 +15,7 @@
 {% endmacro %}
 
 {% macro last_account_activity(account_name) %}
-{% if account_name and uptodate_eligible(account_name) %}
+{% if account_name and account_name|uptodate_eligible %}
 {% set last_account_activity_in_days=api.last_account_activity_in_days(account_name) %}
 {% if last_account_activity_in_days > config['uptodate-indicator-grey-lookback-days'] %}
     <span class="status-indicator status-gray" title="{{ infotext['gray'] }} ({{ last_account_activity_in_days }} days ago)"></span>

--- a/fava/templates/macros/_account_macros.html
+++ b/fava/templates/macros/_account_macros.html
@@ -28,7 +28,7 @@
     {{ account_name|last_segment if last_segment else account_name }}
 </a>
 
-{% if config.user.getboolean('uptodate-indicator-show-everywhere') %}
+{% if config['uptodate-indicator-show-everywhere'] %}
     {{ last_account_activity(account_name) }}
     {{ indicator(account_name) }}
 {% endif %}

--- a/fava/templates/macros/_interval_macros.html
+++ b/fava/templates/macros/_interval_macros.html
@@ -1,4 +1,4 @@
-{% set interval = request.args.get('interval', config.user.get('default-interval')) %}
+{% set interval = request.args.get('interval', config['default-interval']) %}
 {% if interval == 'day' %}    {% set interval_label = 'Daily' %}    {% set interval_format_str = "DD.MM.YY" %}{% endif %}
 {% if interval == 'week' %}   {% set interval_label = 'Weekly' %}   {% set interval_format_str = "YYYYWww" %}{% endif %}
 {% if interval == 'month' %}  {% set interval_label = 'Monthly' %}  {% set interval_format_str = "MMM 'YY" %}{% endif %}

--- a/fava/templates/options.html
+++ b/fava/templates/options.html
@@ -9,6 +9,14 @@
     <p class="description">
         You can use the <code>--settings [file]</code> option when starting <code>fava</code> to specify different settings. The settings will be merged with the default-settings, so the table below shows all possible settings-keys.
     </p>
+    <dl>
+        <dt>Default settings:</dt>
+        <dd><a href="{{ url_for('source', file_path=config['DEFAULT_SETTINGS']) }}">{{ config['DEFAULT_SETTINGS'] }}</a></dd>
+        {% if config['USER_SETTINGS'] %}
+        <dt>User settings:</dt>
+        <dd><a href="{{ url_for('source', file_path=config['USER_SETTINGS']) }}">{{ config['USER_SETTINGS'] }}</a></dd>
+        {% endif %}
+    </dl>
     <table class="settings sortable">
         <thead>
             <tr>
@@ -20,13 +28,7 @@
             {% for key, value in config.user.items() | sort %}
             <tr>
                 <td class="num">{{ key }}</td>
-                <td class="num"><pre>
-                {%- if key == "file_user" -%}
-                    <a href="{{ url_for('source', file_path=value) }}">{{ value }}</a>
-                {%- else -%}
-                    {{ value|trim }}
-                {%- endif -%}
-                </pre></td>
+                <td class="num"><pre>{{ value|trim }}</pre></td>
             </tr>
             {% endfor %}
         </tbody>

--- a/fava/templates/options.html
+++ b/fava/templates/options.html
@@ -25,7 +25,7 @@
             </tr>
         </thead>
         <tbody>
-            {% for key, value in config.user.items() | sort %}
+            {% for key, value in config.raw.items('fava') | sort %}
             <tr>
                 <td class="num">{{ key }}</td>
                 <td class="num"><pre>{{ value|trim }}</pre></td>

--- a/fava/templates/source.html
+++ b/fava/templates/source.html
@@ -55,7 +55,7 @@
     <div class="editor-wrapper editor-wrapper-source">
         <div class="editor"
              id="editor-source"
-             data-print-margin-column="{{ config.user.getint('editor-print-margin-column') }}">
+             data-print-margin-column="{{ config['editor-print-margin-column'] }}">
         </div>
     </div>
     <form class="editor-save" action="{{ url_for('source') }}" method="post">

--- a/fava/templates/source.html
+++ b/fava/templates/source.html
@@ -10,7 +10,7 @@
 
 {% block content %}
     <h1>Source</h1>
-    {% if config.user.getboolean('use-external-editor') %}
+    {% if config['use-external-editor'] %}
         <table class="errors sortable">
             <thead>
                 <tr>

--- a/fava/templates/source.html
+++ b/fava/templates/source.html
@@ -1,7 +1,10 @@
 {% extends "_layout.html" %}
 {% set active_page = 'source' %}
 {% set show_filters = False %}
-{% set source_files = api.source_files()+[config_file] %}
+{% set source_files = api.source_files() + [config['DEFAULT_SETTINGS']] %}
+{% if config['USER_SETTINGS'] %}
+    {% set source_files = source_files + [config['USER_SETTINGS']] %}
+{% endif %}
 
 {% block javascript %}{% include "javascript/_editor.html" %}{% endblock %}
 

--- a/fava/templates/statistics.html
+++ b/fava/templates/statistics.html
@@ -39,7 +39,7 @@
         <h3>Update Activity per Account<input type="submit" class="right" id="copy-balances" value="Copy balance directives" title="Click to copy balance directives for accounts (except green ones) to the clipboard:
 
         {% for activity in statistics.activity_by_account %}
-            {% if uptodate_eligible(activity.account) %}
+            {% if activity.account|uptodate_eligible %}
                 {% with status=api.is_account_uptodate(activity.account, look_back_days=config['uptodate-indicator-grey-lookback-days']) %}
                     {% if status != "green" %}
                         {% with account_inventory=api.inventory(activity.account) %}
@@ -64,7 +64,7 @@
                 {% for activity in statistics.activity_by_account %}
                     <tr>
                         <td><a href="{{ url_for('account_with_journal', name=activity.account) }}">{{ activity.account }}</a></td>
-                        {% if uptodate_eligible(activity.account) %}
+                        {% if activity.account|uptodate_eligible %}
                             {% with status=api.is_account_uptodate(activity.account, look_back_days=config['uptodate-indicator-grey-lookback-days']) %}
                                 <td data-sort-value="{{ status_sortorder[status] }}" class="uptodate-indicator">
                                     {% with account_inventory=api.inventory(activity.account)  %}

--- a/fava/templates/statistics.html
+++ b/fava/templates/statistics.html
@@ -40,7 +40,7 @@
 
         {% for activity in statistics.activity_by_account %}
             {% if uptodate_eligible(activity.account) %}
-                {% with status=api.is_account_uptodate(activity.account, look_back_days=config.user.getint('uptodate-indicator-grey-lookback-days')) %}
+                {% with status=api.is_account_uptodate(activity.account, look_back_days=config['uptodate-indicator-grey-lookback-days']) %}
                     {% if status != "green" %}
                         {% with account_inventory=api.inventory(activity.account) %}
                             {% include "_balance_directive.html" %}
@@ -65,7 +65,7 @@
                     <tr>
                         <td><a href="{{ url_for('account_with_journal', name=activity.account) }}">{{ activity.account }}</a></td>
                         {% if uptodate_eligible(activity.account) %}
-                            {% with status=api.is_account_uptodate(activity.account, look_back_days=config.user.getint('uptodate-indicator-grey-lookback-days')) %}
+                            {% with status=api.is_account_uptodate(activity.account, look_back_days=config['uptodate-indicator-grey-lookback-days']) %}
                                 <td data-sort-value="{{ status_sortorder[status] }}" class="uptodate-indicator">
                                     {% with account_inventory=api.inventory(activity.account)  %}
                                         <span class="status-indicator status-{{ status }}" title="{{ account_macros.infotext[status] }}

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     },
     install_requires=[
         'beancount>=2.0b6',
+        'click',
         'pygments>=2.1.1',
         'beancount-pygments-lexer>=0.1.2',
         'markdown2>=2.3.0',

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -5,7 +5,7 @@ from beancount.scripts.example import write_example_file
 from flask import url_for
 import pytest
 
-from fava.application import app
+from fava.application import api, app
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def setup_app(tmpdir):
                            datetime.date(today.year - 3, 1, 1),
                            today, True, fd)
     app.beancount_filename = str(filename)
-    app.api.load_file(app.beancount_filename)
+    api.load_file(app.beancount_filename)
     app.testing = True
 
 


### PR DESCRIPTION
- Use click for the CLI. Much nicer to use than `argparse`. Fix #176.
- Parse all settings explicitly when loading the settings file. Means we can just use `config[settings_key]` to access them later on. Puts all the settings-parsing logic in one place.
- If there's a user settings file, show both the default and the user file on the source page.
- Move more application logic to `application.py`