### PR TITLE
underscore to hyphen in collapse-accounts; reverse order of years in time filter.

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -328,7 +328,7 @@ def should_collapse_account(account_name):
     if not app.config['collapse-accounts']:
         return False
 
-    return account_name in app.config['collapse_accounts']
+    return account_name in app.config['collapse-accounts']
 
 
 @app.template_filter()

--- a/fava/templates/_entry_filters.html
+++ b/fava/templates/_entry_filters.html
@@ -17,7 +17,7 @@
                         </li>
                     {% endif %}
 
-                    {% for time_ in api.active_years %}
+                    {% for time_ in api.active_years|reverse %}
                     <li{% if time_|string == time_filter %} class="selected"{% endif %} data-filter="{{ time_ }}">
                     {% if time_|string == time_filter %}
                         <a href="{{ url_for_current(time=None) }}">{{ time_filter }}</a>


### PR DESCRIPTION
1) Minor bug caused by hyphen instead of underscore.

2) Reversed order of  years in time filter. See #228 