### PR TITLE
minor fix: underscore to hyphen in collapse-accounts

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -328,7 +328,7 @@ def should_collapse_account(account_name):
     if not app.config['collapse-accounts']:
         return False
 
-    return account_name in app.config['collapse_accounts']
+    return account_name in app.config['collapse-accounts']
 
 
 @app.template_filter()


### PR DESCRIPTION
This was causing a minor bug that prevented the collapse-accounts feature from working if enabled.