### PR TITLE
Follow links when clicking on treemap

### DIFF
--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -153,6 +153,9 @@ module.exports.initCharts = function() {
                     mouseleave: function (node, event) {
                         $('.treetable-popover').remove();
                     },
+                    click: function (node, event) {
+                        window.location = $(node.label).attr("href");
+                    },
                     ready: function () {
                         if (chart.data.length == 0) {
                             $('div#' + chart.id).addClass('chart-no-data').html('<div>Chart is empty.</div>');


### PR DESCRIPTION
The treemap's child label is a small hit target. 
With this change, you click anywhere on the treemap box to follow the link.