### PR TITLE
Account tree

### DIFF
--- a/fava/api/serialization.py
+++ b/fava/api/serialization.py
@@ -102,6 +102,23 @@ def serialize_real_account(ra):
     }
 
 
+def zip_real_accounts(ra_list):
+    if not ra_list:
+        return
+    first = ra_list[0]
+    return {
+        'account': first.account,
+        'balance_and_balance_children':
+            [(serialize_inventory(ra.balance, at_cost=True),
+              serialize_inventory(realization.compute_balance(ra),
+                                  at_cost=True))
+             for ra in ra_list],
+        'children': [zip_real_accounts([realization.get(ra, n)
+                                        for ra in ra_list])
+                     for n, a in sorted(first.items())],
+    }
+
+
 def _add_metadata(new_entry, entry):
     new_entry['meta'] = {
         'type': entry.__class__.__name__.lower(),

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
     keyboardShortcuts.global();
 
     // Tree-expanding
-    if ($('table.tree-table').length) {
+    if ($('.tree-table').length) {
         treeTable.initTreeTable();
     };
 
@@ -45,7 +45,7 @@ $(document).ready(function() {
     };
 
     // Documents upload
-    if ($('table.tree-table').length || $('h1.droptarget').length) {
+    if ($('.tree-table').length || $('h1.droptarget').length) {
         documentsUpload.initDocumentsUpload();
     }
 

--- a/fava/static/javascript/tree-table.js
+++ b/fava/static/javascript/tree-table.js
@@ -1,73 +1,18 @@
-function initTreeTable() {
-    // This fixes if there is a tree-balance, no balance and the row is not a parent.
-    // Without this code the tree-balance would not be shown.
-    $('table.tree-table tbody tr td:not(:first)').each(function(index, td) {
-        if ($(td).find('span.balance').length == 0) {
-            $(td).addClass('tree-balance-show');
+module.exports.initTreeTable = function() {
+    $('ol.tree-table span.has-children').click(function(e) {
+        var row = $(this).parents('li').first();
+        if (e.shiftKey === true) {
+            row.find('li').toggleClass('toggled', !row.hasClass('toggled'));
         }
+        row.toggleClass('toggled');
+        row.parents('ol').find('a.expand-all')
+            .toggleClass('hidden', row.parents('ol').find('li.toggled'));
     });
 
-    function getLevel(tableRow) {
-        if ($(tableRow).length == 0) { return 0; }
-        var rowLevel = parseInt($(tableRow).attr('data-level'));
-        return rowLevel;
-    }
-
-    var level = 1;
-    $('table.tree-table tr').each(function() {
-        var nextLevel = getLevel($(this).next());
-        if (nextLevel <= level) { $(this).children().first().addClass('leaf'); }
-        level = nextLevel;
-    });
-
-    $('table.tree-table tr td:first-child:not(.leaf) a.account').each(function() {
-        $(this).append('<span class="expander" title="Hold the Shift-key while clicking to expand all children"></span>');
-    });
-
-    function toggleTreeTableRow(row, hide, all) {
-        var expander = row.find('span.expander');
-        var level = getLevel(row);
-        expander.toggleClass('toggled', hide);
-        row.toggleClass('hides', hide);
-        row = row.next();
-        while (row.length > 0 && getLevel(row) > level) {
-            if (hide === true) {
-                row.toggleClass('hidden', hide);
-                row.find('span.expander').removeClass('toggled');
-            } else if (all === true) {
-                row.toggleClass('hidden', hide);
-            } else {
-                    if (getLevel(row) == (level + 1)) {
-                        row.toggleClass('hides', !hide);
-                        row.toggleClass('hidden', hide);
-                        row.find('span.expander').addClass('toggled');
-                    }
-            }
-
-            row = row.next();
-        }
-    }
-
-    $('table.tree-table span.expander').click(function(e) {
-        var row = $(this).parents('tr');
-        var all = e.shiftKey === true;
-        toggleTreeTableRow(row, !row.hasClass('hides'), all);
-        $('table.tree-table a.expand-all').addClass('not-fully-expanded');
-        return false;
-    });
-
-    $('table.tree-table tr.hides').each(function() {
-        toggleTreeTableRow($(this), true, false);
-    });
-
-    $('table.tree-table').on('click', 'a.expand-all.not-fully-expanded', function(e) {
+    $('ol.tree-table').on('click', 'a.expand-all', function(e) {
         e.preventDefault();
         var $this = $(e.target);
-        var row = $this.parents('table').find('tbody tr').first();
-        toggleTreeTableRow(row, false, true);
-        $this.removeClass('not-fully-expanded');
-        return false;
+        $this.parents('ol').find('li.toggled').removeClass('toggled');
+        $this.addClass('hidden');
     });
 }
-
-module.exports.initTreeTable = initTreeTable;

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -138,7 +138,7 @@ header {
             span.status-indicator {
                 border-radius: 10px;
                 height: 10px;
-                margin-left: 10px;
+                margin: 0 0 0 10px;
                 width: 10px;
 
                 &.status-gray { margin-left: 0; }
@@ -297,6 +297,8 @@ article {
         }
     }
 
+    td.account a,
+    a.account { font-weight: bold; }
 
     dl {
         dt {
@@ -317,7 +319,7 @@ article {
     }
 
     ul a,
-    p a {
+    p > a {
         text-decoration: underline;
 
         &:hover { color: darken($color_links, 10); }
@@ -426,6 +428,7 @@ ul.warnings {
 
 span.status-indicator {
     display: inline-block;
+    margin: 5px;
     width: 6px;
     height: 6px;
     border-radius: 6px;
@@ -495,8 +498,6 @@ table {
             width: 10rem;
         }
 
-        a.account,
-        &.account a { font-weight: bold; }
     }
 
     thead th,

--- a/fava/static/sass/_journal-table.scss
+++ b/fava/static/sass/_journal-table.scss
@@ -47,25 +47,45 @@
     }
 }
 
+ol.tree-table,
 ol.journal-table {
-    width: 100%;
-
-    p, li, ul {
+    p, li, ul, ol {
         padding: 0;
         margin: 0;
     }
 
     p {
         display: flex;
-        border-bottom: thin solid $color_journaltable_border;
     }
+
     a {
         text-decoration: none;
     }
 
-    >li {
-        &:nth-child(2n) { background: darken($color_background, 2); }
+    p > span {
+        padding: 2px 4px;
+        margin: 0;
+        flex-shrink:0;
+
+        &.num {
+            font: 1em $font_family_monospaced;
+            color: $color_text;
+            text-align: right;
+        }
     }
+
+    .head {
+        color: $color_journaltable_header;
+        font-weight: bold;
+        background: $color_treetable_header_bg;
+        span {
+            border: none;
+        }
+    }
+}
+
+ol.journal-table {
+    p { border-bottom: thin solid $color_journaltable_border; }
 
     li {
         // Journal entry types
@@ -91,9 +111,7 @@ ol.journal-table {
             opacity: 0.6;
         }
 
-        &.transaction {
-            cursor: pointer;
-        }
+        &.transaction { cursor: pointer; }
 
 
         dl.metadata {
@@ -127,9 +145,6 @@ ol.journal-table {
     }
 
     span {
-        padding: 2px 4px;
-        margin: 0;
-
         &.position,
         &.price,
         &.cost,
@@ -137,11 +152,6 @@ ol.journal-table {
         &.balance {
             width: 9rem;
             border-left: 1px solid $color_journaltable_border;
-        }
-        &.num {
-            font: 1em $font_family_monospaced;
-            color: $color_text;
-            text-align: right;
         }
 
         &.datecell { width: 6rem; }
@@ -188,14 +198,4 @@ ol.journal-table {
             &.leg-pending { background-color: $color_journalentry_postingwarning; }
         }
     }
-
-    .head {
-        color: $color_journaltable_header;
-        font-weight: bold;
-        background: $color_treetable_header_bg;
-        span {
-            border: none;
-        }
-    }
-
 }

--- a/fava/static/sass/_tree-table.scss
+++ b/fava/static/sass/_tree-table.scss
@@ -1,97 +1,107 @@
-// Collapsable trees
+// Collapsible trees
+//
+// some of the shared styles are in `_journal_table.scss`
 
-table.tree-table {
+ol.tree-table {
     &.fullwidth {
         overflow-x: auto;
         max-width: 100%;
         display: block;
     }
 
+    p { margin-top: -1px; }
+
+    .head span {
+        border: 1px solid $color_treetable_header_bg;
+        span {
+            flex-grow: 1;
+        }
+    }
+
+    p > span {
+        border: 1px solid $color_treetable_header_bg;
+        margin-right: -1px;
+        flex-shrink:0;
+
+        &.account {
+            flex: 1;
+            align-items: center;
+            display: flex;
+            min-width: 200px;
+
+            @for $i from 1 through 5 {
+                &.account-depth-#{$i} {
+                    min-width: 200px - $i * 20px;
+                    margin-left: $i * 20px;
+                }
+            }
+
+            &.has-children {
+                cursor: pointer;
+            }
+
+            a {
+                margin-left:15px;
+            }
+        }
+
+        &.num-header,
+        &.num { width: 8rem; }
+        &.other-header,
+        &.other { width: 10rem; }
+    }
+
     &:hover {
-        // class ".tree-balance-show" is added via JavaScript
-        tr.parent td.num,
-        tr td.num.tree-balance-show {
+        .balance-children {
             color: lighten($color_text, 30);
         }
-        tr.hides td.num {
-            color: $color_text;
-        }
     }
 
-    td.account a {
-        position: relative;
-        margin-left: 15px;
-    }
-
-    // td.account.leaf a { margin-left: 10px; }
-
-    tr.hides {
-        span.tree-balance {
+    .has-balance {
+        .balance {
             display: block;
-            color: $color_text;
         }
-
-        span.balance {
+        .balance-children {
             display: none;
         }
     }
 
-    tr {
-        &.parent td.num,
-        td.num.tree-balance-show {
-            color: lighten($color_text, 60);
+    .balance-children {
+        color: lighten($color_text, 60);
+    }
+
+    li.toggled {
+        ol { display:none; }
+
+        .balance {
+            display: none;
         }
 
-        &.hides td.num {
-            span.tree-balance { display: block; }
-            span.balance { display: none; }
-        }
-
-        td {
-            &.num {
-                span.balance { display: block; }
-                span.tree-balance { display: none; }
-            }
-
-            &.num.tree-balance-show span.tree-balance { display: block; }
-
-            &:first-child { min-width: 200px; }
-            &.account-level-1 { padding-left: 8px; }
-
-            @for $i from 2 through 12 {
-                &.account-level-#{$i} {
-                    padding-left: -0.5em + $i * 1.3;
-                }
-            }
+        .balance-children {
+            display: block;
+            color: $color_text;
         }
     }
 
     span.expander {
         width: 5px;
+        margin: 0 -10px 0 0;
         height: 5px;
         border-left: 5px solid transparent;
         border-right: 5px solid transparent;
         border-top: 5px solid $color_treetable_expander;
-        position: absolute;
-        left: -15px;
-        top: 5px;
         cursor: pointer;
+    }
 
-        &.toggled {
-            border-top: 5px solid transparent;
-            border-bottom: 5px solid transparent;
-            border-left: 5px solid $color_treetable_expander;
-            left: -12px;
-            top: 2px;
-        }
+    .toggled span.expander {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        border-left: 5px solid $color_treetable_expander;
+        margin: 0 -13px 0 3px;
     }
 
     a.expand-all {
-       float: right;
        color: lighten($color_text, 40);
        font-weight: normal;
-       display: none;
-
-       &.not-fully-expanded { display: inline; }
     }
 }

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -4,71 +4,74 @@
 {% endif %}
 
 {% set show_other_column = (operating_currencies|sort != options['commodities']|list|sort) %}
-<table class="tree-table">
-    <thead>
-        <tr>
-            <th class="first">Account <a href="" class="expand-all" title="Expand all accounts">Expand all</a></th>
+
+<ol class="tree-table">
+    <li class="head">
+        <p>
+        <span class="account"><span>Account</span><a href="" class="expand-all hidden" title="Expand all accounts">Expand all</a></span>
         {% for currency in operating_currencies %}
-            <th>{{ currency }}</th>
+            <span class="num-header">{{ currency }}</span>
         {% endfor %}
-            {% if show_other_column %}<th>Other</th>{% endif %}
-        </tr>
-    </thead>
-    <tbody>
-        {% for account in real_accounts recursive %}
-            {% if account|show_account %}
-            {% with account_level = loop.depth %}
-            <tr data-level="{{ account_level }}" data-is-parent="{% if not account.is_leaf %}true{% else %}false{% endif %}"{% if account.account|should_collapse_account %} class="hides"{% endif %}>
-                <td class="account account-level-{{ account_level }} droptarget" data-level="{{ account_level }}" data-account-name="{{ account.account }}">
-                    {{ account_macros.account_name(account.account, last_segment=True) }}
-                </td>
-            {% for currency in operating_currencies %}
-                <td class="num">
-                {% if currency in account.balance %}
-                    <span class="balance">{{ account.balance[currency]|format_currency(currency) }}</span>
-                {% endif %}
-                {% if currency in account.balance_children %}
-                    <span class="tree-balance">{{ account.balance_children[currency]|format_currency(currency) }}</span>
-                {% endif %}
-                </td>
-            {% endfor %}
-            {% if show_other_column %}
-                <td class="num other">
+            {% if show_other_column %}<span class="other">Other</span>{% endif %}
+        </p>
+    </li>
+{% for account in real_accounts recursive %}
+    {% if account|show_account %}
+        <li>
+        <p>
+        <span class="account account-depth-{{ loop.depth0 }} droptarget{{ '' if not account.children else ' has-children'}}{% if account.account|should_collapse_account %} toggled{% endif %}" data-account-name="{{ account.account }}">
+            {% if account.children %}<span class="expander" title="Hold the Shift-key while clicking to expand all children"></span>{% endif %}
+        {{ account_macros.account_name(account.account, last_segment=True) }}</span>
+    {% for currency in operating_currencies %}
+        <span class="num{{ ' has-balance' if account.balance else '' }}">
+        {% if currency in account.balance %}
+            <span class="balance">{{ account.balance[currency]|format_currency(currency) }}</span>
+        {% endif %}
+        {% if currency in account.balance_children %}
+            <span class="balance-children">{{ account.balance_children[currency]|format_currency(currency) }}</span>
+        {% endif %}
+        </span>
+    {% endfor %}
+    {% if show_other_column %}
+        <span class="num other{{ ' has-balance' if account.balance else '' }}">
+        {% for currency in options['commodities'] if currency not in operating_currencies %}
+            {% if currency in account.balance %}
+                <span class="balance">
+                    {{- account.balance[currency]|format_currency(currency) }} {{ currency -}}
+                </span>
+            {% endif %}
+            {% if currency in account.balance_children %}
+                <span class="balance-children">
+                    {{- account.balance_children[currency]|format_currency(currency) }} {{ currency -}}
+                </span>
+            {% endif %}
+        {% endfor %}
+        </span>
+    {% endif %}
+    </p>
+    <ol>
+    {{ loop(account.children) }}
+    </ol>
+    </li>
+    {% endif %}
+{% endfor %}
+{% if totals %}
+        <li class="head">
+            <p>
+            <span class="account">&nbsp;</span>
+        {% for currency in operating_currencies %}
+            <span class="num">{{ real_accounts[0].balance_children[currency]|format_currency(currency) }}</span>
+        {% endfor %}
+        {% if show_other_column %}
+            <span class="num other">
                 {% for currency in options['commodities'] %}
-                    {% if currency not in operating_currencies %}
-                        {% if currency in account.balance %}
-                            <span class="balance">{{ account.balance[currency]|format_currency(currency) }} {{ currency }}</span>
-                        {% endif %}
-                        {% if currency in account.balance_children %}
-                            <span class="tree-balance">{{ account.balance_children[currency]|format_currency(currency) }} {{ currency }}</span>
-                        {% endif %}
+                    {% if currency not in  operating_currencies and real_accounts[0].balance_children[currency] %}
+                        {{ real_accounts[0].balance_children[currency]|format_currency(currency) }} {{ currency }}<br>
                     {% endif %}
                 {% endfor %}
-                </td>
-            {% endif %}
-            </tr>
-            {% endwith %}
-            {{ loop(account.children) }}
-            {% endif %}
-        {% endfor %}
-    </tbody>
-    {% if totals %}
-        <tfoot>
-            <tr>
-                <td>&nbsp;</td>
-            {% for currency in operating_currencies %}
-                <td class="num">{{ real_accounts[0].balance_children[currency]|format_currency(currency) }}</td>
-            {% endfor %}
-            {% if show_other_column %}
-                <td class="num">
-                    {% for currency in options['commodities'] %}
-                        {% if currency not in  operating_currencies and real_accounts[0].balance_children[currency] %}
-                            {{ real_accounts[0].balance_children[currency]|format_currency(currency) }} {{ currency }}<br>
-                        {% endif %}
-                    {% endfor %}
-                </td>
-            {% endif %}
-            </tr>
-        </tfoot>
-    {% endif %}
-</table>
+            </span>
+        {% endif %}
+            </p>
+        </li>
+{% endif %}
+</ol>

--- a/fava/templates/account.html
+++ b/fava/templates/account.html
@@ -35,63 +35,58 @@
         {% endwith %}
     {% else %}
         {% set interval_balances, dates = api.interval_balances(interval, account_name, accumulate) %}
+        {% if interval_balances %}
 
-        {% for begin_date, end_date in dates[-3:]|reverse %}
-            {{ charts.treemap(account_name, begin_date, end_date, label=interval_macros.format_date(end_date)) }}
-        {% endfor %}
-        <table class="fullwidth tree-table">
-            <thead>
-                <tr>
-                    <th>Account <a href="" class="expand-all" title="Expand all accounts">Expand all</a></th>
-                    {% for begin_date, _ in dates|reverse %}
-                        <th>{{ interval_macros.format_date(begin_date) }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-            {% for row in interval_balances %}
-                {% with account_level = row[0].account|account_level  %}
-                <tr data-level="{{ account_level }}" data-is-parent="{% if not row[0].is_leaf %}true{% else %}false{% endif %}">
-                    <td class="account account-level-{{ account_level }}" data-level="{{ account_level }}">
-                        <a href="{{ url_for('account_with_journal', name=row[0].account) }}" class="account">{{ row[0].account|last_segment }}</a>
-                    </td>
-
-                    {% for entry in row|reverse %}
-                        <td class="num">
-                            {% if entry.balance %}
-                                <span class="balance">
-                                {% for currency, number in entry.balance.items() %}
-                                    {{ number|format_currency(currency) }} {{ currency }}<br>
-                                {% endfor %}
-                                </span>
-                            {% endif %}
-                            {% if entry.balance_children %}
-                                <span class="tree-balance">
-                                {% for currency, number in entry.balance_children.items() %}
-                                    {{ number|format_currency(currency) }} {{ currency }}<br>
-                                {% endfor %}
-                                </span>
-                            {% endif %}
-                        </td>
-                    {% endfor %}
-                </tr>
-                {% endwith %}
+            {% for begin_date, end_date in dates[-3:]|reverse %}
+                {{ charts.treemap(account_name, begin_date, end_date, label=interval_macros.format_date(end_date)) }}
             {% endfor %}
-            </tbody>
-            <tfoot>
-                <tr>
-                    <td>&nbsp;</td>
-                    {% for entry in interval_balances[0]|reverse %}
-                    <td class="num">
-                        {% for currency, number in entry.balance_children.items() %}
-                            {% if number %}
-                                {{ number|format_currency(currency) }} {{ currency }}<br>
-                            {% endif %}
-                        {% endfor %}
-                    </td>
+
+        <ol class="fullwidth tree-table">
+            <li class="head">
+                <p>
+                <span class="account"><span>Account</span><a href="" class="expand-all hidden" title="Expand all accounts">Expand all</a></span>
+                {% for begin_date, _ in dates|reverse %}
+                    <span class="other-header">{{ interval_macros.format_date(begin_date) }}</span>
+                {% endfor %}
+                </p>
+            </li>
+        {% for account in [interval_balances] recursive %}
+            <li>
+                <p>
+                <span class="account account-depth-{{ loop.depth0 }} droptarget{{ '' if not account.children else ' has-children'}}{% if account.account|should_collapse_account %} toggled{% endif %}" data-account-name="{{ account.account }}">
+                    {% if account.children %}<span class="expander" title="Hold the Shift-key while clicking to expand all children"></span>{% endif %}
+                {{ account_macros.account_name(account.account, last_segment=True) }}</span>
+            {% for balance, balance_children in account.balance_and_balance_children|reverse %}
+                <span class="num other{{ ' has-balance' if balance else '' }}">
+                    {% for currency, number in balance.items() %}
+                        <span class="balance">{{ number|format_currency(currency) }} {{ currency }}</span>
                     {% endfor %}
-                </tr>
-            </tfoot>
-        </table>
+                    {% for currency, number in balance_children.items() %}
+                        <span class="balance-children">{{ number|format_currency(currency) }} {{ currency }}</span>
+                    {% endfor %}
+                </span>
+            {% endfor %}
+            </p>
+            <ol>
+            {{ loop(account.children) }}
+            </ol>
+            </li>
+        {% endfor %}
+            <li class="head">
+                <p>
+                <span class="account">&nbsp;</span>
+                {% for _, balance_children in interval_balances.balance_and_balance_children|reverse %}
+                <span class="num other-header">
+                    {% for currency, number in balance_children.items() %}
+                        {% if number %}
+                            {{ number|format_currency(currency) }} {{ currency }}<br>
+                        {% endif %}
+                    {% endfor %}
+                </span>
+                {% endfor %}
+                </p>
+            </li>
+        </ol>
+            {% endif %}
     {% endif %}
 {% endblock %}

--- a/fava/templates/trial_balance.html
+++ b/fava/templates/trial_balance.html
@@ -13,8 +13,10 @@
         {{ charts.treemap(api.options['name_{}'.format(base_account)]) }}
     {% endfor %}
 
+    <div class="halfleft">
     {% with table_title=None, real_accounts=api.trial_balance(), totals=False %}
         {% include "_tree_table.html" %}
     {% endwith %}
+    </div>
 
 {% endblock %}


### PR DESCRIPTION
I've refactored the account "tree-tables" to also use ordered lists and flexbox like the journal.

- This means we can better preserve the hierarchical structure of the account tree, which greatly simplifies the Javascript part.
- The account "table cells" are not all of the same size anymore but also indented according to the hierarchy, which looks nicer IMHO.
- The whole account "cell" is now clickable to collapse the account.

I'll clean up the SCSS some more in the coming days and then merge this.