### PR TITLE
Sunburst

### DIFF
--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -434,7 +434,6 @@ class BeancountReportAPI(object):
 
     def treemap_data(self, account_name, begin_date=None, end_date=None):
         return {
-            'label': account_name,
             'balances': self.balances(account_name, begin_date, end_date),
             'modifier': get_account_sign(account_name, self.account_types),
         }

--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -279,6 +279,9 @@ class BeancountReportAPI(object):
         return realization.get(realization.realize(entries, min_accounts),
                                account_name)
 
+    def get_account_sign(self, account_name):
+        return get_account_sign(account_name, self.account_types)
+
     def balances(self, account_name, begin_date=None, end_date=None):
         real_account = self._real_account(account_name, self.entries,
                                           begin_date, end_date)
@@ -430,12 +433,6 @@ class BeancountReportAPI(object):
             'filename': entry.meta['filename'],
             'lineno': entry.meta['lineno'],
             'journal': self._journal(matching_entries),
-        }
-
-    def treemap_data(self, account_name, begin_date=None, end_date=None):
-        return {
-            'balances': self.balances(account_name, begin_date, end_date),
-            'modifier': get_account_sign(account_name, self.account_types),
         }
 
     def linechart_data(self, account_name):

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -135,6 +135,8 @@ function treeMap() {
     return chart;
 }
 
+var sunburstColorScale = d3.scale.category20c();
+
 function sunburstChart() {
     var width, height;
     var div, vis;
@@ -148,7 +150,7 @@ function sunburstChart() {
             .attr('id', div_id + '-label')
             .style('top', (height / 2) + 'px');
 
-        account_label = label.append('span')
+        account_label = label.append('a')
             .attr('class', 'chart-sunburst-account')
             .attr('id', div_id + '-account');
 
@@ -172,7 +174,7 @@ function sunburstChart() {
 
     function buildHierarchy(rootNode, currency) {
         return {
-            'name': rootNode.account,
+            'account': rootNode.account,
             'currency': currency,
             'balance': rootNode.balance_children[currency],
             'children': rootNode.children.map(function(childNode) {
@@ -219,9 +221,14 @@ function sunburstChart() {
             .attr('display', function(d) { return d.depth ? null : 'none'; })
             .attr('d', arc)
             .attr('fill-rule', 'evenodd')
-            .style('fill', function(d) { return colorScale(d.name); })
+            .attr('class', 'sunburst-segment')
+            .style('fill', function(d) { return sunburstColorScale(d.account); })
             .style('opacity', 1)
-            .on('mouseover', mouseOver);
+            .on('mouseover', mouseOver)
+            .on('click', function(d) {
+                window.location = accountUrl.replace('REPLACEME', d.account);
+                d3.event.stopPropagation()
+            });
 
         // Add the mouseleave handler to the bounding circle.
         div.on('mouseleave', mouseLeave);
@@ -232,7 +239,8 @@ function sunburstChart() {
     // Fade all but the current sequence
     function mouseOver(d) {
         balance_label.text(d.balance);
-        account_label.text(d.name);
+        account_label.text(d.account)
+                     .attr('href', accountUrl.replace('REPLACEME', d.account));
         currency_label.text(d.currency);
 
         label

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -14,9 +14,7 @@ var defaultOptions = {
         onlyInteger: true,
         position: 'end',
         scaleMinSpace: 15,
-        labelInterpolationFnc: function(value) {
-            return value;
-        },
+        labelInterpolationFnc: helpers.formatCurrency,
         referenceValue: 0,
     },
     plugins: [

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -64,6 +64,7 @@ function treeMap() {
 
         setSize();
 
+        root = div.datum()
         cells = svg.selectAll('g')
             .data(treemap.size([width, height]).nodes(root))
           .enter().append('g')
@@ -100,11 +101,6 @@ function treeMap() {
 
     chart.tooltipText = function(f) {
         tooltipText = f;
-        return chart;
-    }
-
-    chart.root = function(r) {
-        root = r;
         return chart;
     }
 
@@ -264,8 +260,8 @@ module.exports.initCharts = function() {
                     var tm = treeMap()
                         .value(function(d) { return d.balance[currency] * chart.modifier; })
                         .tooltipText(function(d) { return d.value + ' ' + currency  + '<em>' + d.account + '</em>'; })
-                        .root(chart.root)
                     div
+                        .datum(chart.root)
                         .call(tm)
                     window.charts[chart.id] = tm;
                 })

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -31,7 +31,7 @@ var container;
 
 var colorScale = d3.scale.category20c();
 
-var addInternalNodesAsLeaves = function(node) {
+function addInternalNodesAsLeaves(node) {
     $.each(node.children, function(i, o) {
         addInternalNodesAsLeaves(o);
     });
@@ -88,7 +88,10 @@ function treeMap(div, data, currency) {
             .attr("text-anchor", "middle")
             .text(function(d) { return d.account.split(':').pop(); })
             .style('opacity', 0)
-            .on('click', function(d) { console.log(d.account);d3.event.stopPropagation() })
+            .on('click', function(d) {
+                window.location = accountUrl.replace('REPLACEME', d.account);
+                d3.event.stopPropagation()
+            })
 
         zoom(root);
 

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -50,13 +50,19 @@ function treeMap() {
     var transitionDelay = 200;
     var div, svg, root, current_node, cells, leaves, tooltipText;
 
-    function chart(div) {
+    function setSize() {
         width = parseInt(container.style('width'), 10);
-        height = width / 2.5;
-        svg = div.append("svg")
+        height = Math.min(width / 2.5, 400);
+        svg
             .attr('width', width)
             .attr('height', height)
+    }
+
+    function chart(div) {
+        svg = div.append("svg")
             .attr('class', 'treemap')
+
+        setSize();
 
         cells = svg.selectAll('g')
             .data(treemap.size([width, height]).nodes(root))
@@ -104,8 +110,7 @@ function treeMap() {
 
     chart.update = function() {
         transitionDelay = 0;
-        width = parseInt(container.style('width'), 10);
-        height = width / 2.5;
+        setSize();
         zoom(current_node);
         transitionDelay = 200;
     }
@@ -114,9 +119,6 @@ function treeMap() {
         kx =  width / d.dx, ky = height / d.dy;
         x.range([0, width]).domain([d.x, d.x + d.dx]);
         y.range([0, height]).domain([d.y, d.y + d.dy]);
-        svg
-            .attr('width', width)
-            .attr('height', height)
 
         var t = cells.transition()
             .duration(transitionDelay)

--- a/fava/static/javascript/helpers.js
+++ b/fava/static/javascript/helpers.js
@@ -53,7 +53,7 @@ if (toLocaleStringSupportsOptions() === false) {
 };
 
 // Formats the given number to two fixed decimals.
-window.formatCurrency = function (x) {
+module.exports.formatCurrency = function (x) {
     return parseFloat(x).toLocaleString(undefined, { minimumFractionDigits: 2 })
 }
 

--- a/fava/static/package.json
+++ b/fava/static/package.json
@@ -25,11 +25,11 @@
     "chartist-plugin-tooltip": "github:globegitter/chartist-plugin-tooltip",
     "clipboard": "^1.5.8",
     "compass-mixins": "^0.12.7",
+    "d3": "^3.5.16",
     "jquery": "^2.2.0",
+    "jquery-dragster": "github:catmanjan/jquery-dragster",
     "jquery-query-object": "^2.2.3",
     "jquery-stupid-table": "github:medsabir/Stupid-Table-Plugin#feat-npm-publish",
-    "jquery-treemap": "github:lrgalego/jquery-treemap",
-    "mousetrap": "^1.5.3",
-    "jquery-dragster": "github:catmanjan/jquery-dragster"
+    "mousetrap": "^1.5.3"
   }
 }

--- a/fava/static/sass/_charts.scss
+++ b/fava/static/sass/_charts.scss
@@ -113,12 +113,12 @@
     text-align: center;
     z-index: 2;
 
-    span.chart-sunburst-account {
+    a.chart-sunburst-account {
         display: block;
         font-weight: 700;
         font-size: 13px;
         color: $color_text;
-        margin-bottom: 6px
+        margin-bottom: 6px;
     }
 
     span.chart-sunburst-balance,
@@ -131,6 +131,10 @@
         color: lighten($color_text, 40);
         margin-left: 4px;
     }
+}
+
+.sunburst-segment {
+    cursor: pointer;
 }
 
 .chartist-tooltip,

--- a/fava/static/sass/_charts.scss
+++ b/fava/static/sass/_charts.scss
@@ -108,6 +108,31 @@
     }
 }
 
+.chart-sunburst-label {
+    position: absolute;
+    text-align: center;
+    z-index: 2;
+
+    span.chart-sunburst-account {
+        display: block;
+        font-weight: 700;
+        font-size: 13px;
+        color: $color_text;
+        margin-bottom: 6px
+    }
+
+    span.chart-sunburst-balance,
+    span.chart-sunburst-currency {
+        font-family: $font_family_monospaced;
+        font-size: 14px;
+    }
+
+    span.chart-sunburst-currency {
+        color: lighten($color_text, 40);
+        margin-left: 4px;
+    }
+}
+
 .chartist-tooltip,
 #tooltip {
     font-family: $font_family_monospaced;

--- a/fava/static/sass/_charts.scss
+++ b/fava/static/sass/_charts.scss
@@ -98,6 +98,10 @@
 .treemap {
     shape-rendering: crispEdges;
 
+    rect {
+        stroke: #fff;
+    }
+
     text {
         fill: $color_text;
         cursor: pointer;

--- a/fava/static/sass/_charts.scss
+++ b/fava/static/sass/_charts.scss
@@ -96,6 +96,8 @@
 }
 
 .treemap {
+    shape-rendering: crispEdges;
+
     text {
         fill: $color_text;
         cursor: pointer;

--- a/fava/static/sass/_charts.scss
+++ b/fava/static/sass/_charts.scss
@@ -35,15 +35,13 @@
     }
 
     .chart-container {
-        clear:right;
         position: relative;
-        height: 240px;
-
+        min-height: 100px;
     }
 
-    .chart-no-data div,
+    .ct-chart > p,
     .loading {
-        padding-top: 100px;
+        padding-top: 30px;
         text-align: center;
         font-style: italic;
         color: lighten($color_text, 60);
@@ -97,10 +95,16 @@
     }
 }
 
+.treemap {
+    text {
+        fill: $color_text;
+        cursor: pointer;
+    }
+}
+
 .chartist-tooltip,
-#treemap-popover {
+#tooltip {
     font-family: $font_family_monospaced;
-    font-size: 13px;
     position: absolute;
     z-index: 12;
     text-align: center;
@@ -123,15 +127,16 @@
 
     em {
         font-family: $font_family;
-        font-size: 0.9em;
         display: block;
         margin-top: 5px;
         color: darken($color_background, 50);
     }
 }
 
-#treemap-popover {
-    min-width: 10em;
+#tooltip {
+    opacity: 0;
+    transform: translate(-50%, -100%);
+    pointer-events: none;
 }
 
 .chartist-tooltip {
@@ -145,14 +150,4 @@
     transition: opacity .2s linear;
 
     &.tooltip-show { opacity: 1; }
-}
-
-.treemap-node .treemap-label {
-    z-index: 8;
-
-    a {
-        color: $color_treemap_text;
-
-        &:hover { text-decoration: underline; }
-    }
 }

--- a/fava/templates/account.html
+++ b/fava/templates/account.html
@@ -39,7 +39,7 @@
         {% if interval_balances %}
 
             {% for begin_date, end_date in dates[-3:]|reverse %}
-                {{ charts.treemap(account_name, begin_date, end_date, label=interval_macros.format_date(end_date)) }}
+                {{ charts.treemap(account_name, begin_date, end_date, label=interval_macros.format_date(begin_date)) }}
             {% endfor %}
 
         <ol class="fullwidth tree-table">

--- a/fava/templates/account.html
+++ b/fava/templates/account.html
@@ -21,6 +21,7 @@
 
     {% if not journal %}
         {{ charts.treemap(account_name) }}
+        {{ charts.sunburst(account_name) }}
     {% endif %}
 
     <div class="headerline">
@@ -41,7 +42,6 @@
             {% for begin_date, end_date in dates[-3:]|reverse %}
                 {{ charts.treemap(account_name, begin_date, end_date, label=interval_macros.format_date(begin_date)) }}
             {% endfor %}
-
         <ol class="fullwidth tree-table">
             <li class="head">
                 <p>

--- a/fava/templates/balance_sheet.html
+++ b/fava/templates/balance_sheet.html
@@ -13,6 +13,10 @@
     {{ charts.treemap(api.options['name_liabilities']) }}
     {{ charts.treemap(api.options['name_equity']) }}
 
+    {{ charts.sunburst(api.options['name_assets']) }}
+    {{ charts.sunburst(api.options['name_liabilities']) }}
+    {{ charts.sunburst(api.options['name_equity']) }}
+
     <div class="halfleft">
         {% with table_title="Assets", real_accounts=api.closing_balances(api.options['name_assets']), totals=True %}
             {% include "_tree_table.html" %}

--- a/fava/templates/charts/_chart_account_balance.html
+++ b/fava/templates/charts/_chart_account_balance.html
@@ -2,15 +2,7 @@
     window.chartData.push({
         label: "Account balance",
         type: "line",
-        options: {
-            axisY: {
-                offset: 60,
-                position: 'end',
-                labelInterpolationFnc: function(value) {
-                    return formatCurrency(value)
-                }
-            }
-        },
+        options: {},
         data: {
             series: [
                 {% for currency in operating_currencies %}

--- a/fava/templates/charts/_chart_interval_net_worth.html
+++ b/fava/templates/charts/_chart_interval_net_worth.html
@@ -7,13 +7,6 @@
         type: "line",
         options: {
             dateFormat: "{{ interval_macros.interval_format_str }}",
-            axisY: {
-                offset: 60,
-                position: 'end',
-                labelInterpolationFnc: function(value) {
-                    return formatCurrency(value)
-                }
-            }
         },
         data: {
             series: [{

--- a/fava/templates/charts/_chart_interval_totals.html
+++ b/fava/templates/charts/_chart_interval_totals.html
@@ -5,13 +5,6 @@
         type:  "bar",
         options: {
             dateFormat: "{{ interval_macros.interval_format_str }}",
-            axisY: {
-                offset: 60,
-                position: 'end',
-                labelInterpolationFnc: function(value) {
-                    return formatCurrency(value)
-                }
-            }
         },
         data: {
             labels: [

--- a/fava/templates/charts/_chart_skeleton.html
+++ b/fava/templates/charts/_chart_skeleton.html
@@ -21,7 +21,6 @@
 
     <script>
         window.interval = "{{ interval_macros.interval }}";
-        {# window.intervalLabel = "{{ interval_macros.interval_label }}"; #}
-        {# window.intervalFormatStr = "{{ interval_macros.interval_format_str }}"; #}
+        window.operating_currencies = {{ operating_currencies|tojson|safe }};
     </script>
 </div>

--- a/fava/templates/charts/_chart_skeleton.html
+++ b/fava/templates/charts/_chart_skeleton.html
@@ -18,9 +18,9 @@
         <div class="loading">Loading charts&hellip;</div>
     </div>
     <div id="chart-labels" class="chart-labels{% if not show_charts %} hidden{% endif %}"> </div>
-
-    <script>
-        window.interval = "{{ interval_macros.interval }}";
-        window.operating_currencies = {{ operating_currencies|tojson|safe }};
-    </script>
 </div>
+<script>
+    window.interval = "{{ interval_macros.interval }}";
+    window.operating_currencies = {{ operating_currencies|tojson|safe }};
+    window.accountUrl = "{{ url_for('account_with_journal', name='REPLACEME') }}";
+</script>

--- a/fava/templates/charts/_charts.html
+++ b/fava/templates/charts/_charts.html
@@ -3,7 +3,8 @@
 window.chartData.push({
     type:  "treemap",
     label: "{{ account_name if not label else label }}",
-    data: {{ api.treemap_data(account_name, begin_date, end_date)|tojson|safe }}
+    modifier: {{ api.get_account_sign(account_name) }},
+    root: {{ api.balances(account_name, begin_date, end_date)[0]|tojson|safe }}
 });
 </script>
 {% endmacro %}

--- a/fava/templates/charts/_charts.html
+++ b/fava/templates/charts/_charts.html
@@ -8,3 +8,14 @@ window.chartData.push({
 });
 </script>
 {% endmacro %}
+
+{% macro sunburst(account_name, diameter=500, begin_date=None, end_date=None, label=None) %}
+<script>
+window.chartData.push({
+    type:  "sunburst",
+    label: "{{ account_name if not label else label }} (Sunburst)",
+    diameter: {{ diameter }},
+    data: {{ api.balances(account_name, begin_date, end_date)[0]|tojson|safe }}
+});
+</script>
+{% endmacro %}

--- a/fava/templates/charts/_charts.html
+++ b/fava/templates/charts/_charts.html
@@ -1,39 +1,9 @@
 {% macro treemap(account_name, begin_date=None, end_date=None, label=None) %}
-{% set treemap_data = api.treemap_data(account_name) %}
-{% set label=treemap_data.label if not label else label %}
-{% set level=account_name|account_level-1 %}
 <script>
-{% for currency in operating_currencies %}
 window.chartData.push({
-    label: "{{ label }} ({{ currency }})",
     type:  "treemap",
-    options: {
-        dateFormat: "MMM YYYY",
-        treemapColorLevel: {{ level or 1 }}
-    },
-    data: [
-        {% for account in treemap_data.balances recursive %}
-            {% if account.is_leaf and currency in account.balance %}
-                {% set value = account.balance[currency] * (treemap_data.modifier or 1) %}
-                {% if value >= 0 or config['treemaps-show-negative-numbers'] %}
-                {
-                    {% if value < 0 %}
-                    label: '<a href="{{ url_for("account_with_journal", name=account.account) }}"><em>({{ account.account|last_segment }})</em></a>',
-                    value: {{ value|abs }},
-                    {% else %}
-                    label: '<a href="{{ url_for("account_with_journal", name=account.account) }}">{{ account.account|last_segment }}</a>',
-                    value: {{ value }},
-                    {% endif %}
-                    id: '{{ account.account }}-{{ currency }}',
-                    accountName: '{{ account.account }}',
-                    balance: '{{ account.balance[currency]|format_currency }} {{ currency }}'
-                },
-                {% endif %}
-            {% endif %}
-            {{ loop(account.children) }}
-        {% endfor %}
-    ]
+    label: "{{ account_name if not label else label }}",
+    data: {{ api.treemap_data(account_name, begin_date, end_date)|tojson|safe }}
 });
-{% endfor %}
 </script>
 {% endmacro %}

--- a/fava/templates/income_statement.html
+++ b/fava/templates/income_statement.html
@@ -21,6 +21,9 @@
     {{ charts.treemap(api.options['name_income']) }}
     {{ charts.treemap(api.options['name_expenses']) }}
 
+    {{ charts.sunburst(api.options['name_expenses']) }}
+    {{ charts.sunburst(api.options['name_income']) }}
+
     <div class="halfleft">
         {% with table_title="Income", real_accounts=api.balances(options['name_income']), totals=True %}
             {% include "_tree_table.html" %}

--- a/fava/templates/trial_balance.html
+++ b/fava/templates/trial_balance.html
@@ -13,6 +13,10 @@
         {{ charts.treemap(api.options['name_{}'.format(base_account)]) }}
     {% endfor %}
 
+    {% for base_account in ['expenses', 'income', 'assets', 'equity', 'liabilities'] %}
+        {{ charts.sunburst(api.options['name_{}'.format(base_account)]) }}
+    {% endfor %}
+
     <div class="halfleft">
     {% with table_title=None, real_accounts=api.trial_balance(), totals=False %}
         {% include "_tree_table.html" %}


### PR DESCRIPTION
This adds a sunburst chart type (#198) on top of PR #252:

![screenshot](https://cloud.githubusercontent.com/assets/5135450/14402239/4fc61650-fe2f-11e5-8bfd-9124d24e68f3.png)

The code is taken from this example: http://bl.ocks.org/kerryrodden/7090426
I removed the breadcrumb trail and the legend, and adapted the label in the middle to fit fava's needs.

- [x] Make the Account name in the label click-able
- [x] Maybe display two circles next to each other, as there is space available
- [x] There is a bug with the label when switching charts (especially via the `c` keyboard shortcut)
- [x] The name for this chart in the links to the different charts is not yet decided yet. It get's really crowded there, so maybe another mechanism/UI for showing which charts are available is necessary. 
- [x] Add chart to more pages

Open:

- The colors the algorithm chooses are not ideal. Ideally when the inner circle-segment is green, all it's children are shades of green as well.