### PR TITLE
Enable switching between multiple root source files

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -12,7 +12,7 @@ from werkzeug import secure_filename
 from fava import config
 from fava.api import BeancountReportAPI, FilterException
 from fava.api.serialization import BeanJSONEncoder
-from fava.util import uniquify
+from fava.util import slugify, uniquify
 from fava.util.excel import to_csv, to_excel, HAVE_EXCEL
 
 
@@ -23,8 +23,6 @@ app.jinja_env.lstrip_blocks = True
 # the key is currently only required to flash messages
 app.secret_key = '1234'
 
-api = BeancountReportAPI()
-
 app.config['DEFAULT_SETTINGS'] = \
     os.path.join(os.path.dirname(os.path.realpath(__file__)),
                  'default-settings.conf')
@@ -32,10 +30,16 @@ app.config['USER_SETTINGS'] = None
 app.config['HELP_DIR'] = \
     os.path.join(os.path.dirname(os.path.realpath(__file__)), 'docs')
 app.config['HAVE_EXCEL'] = HAVE_EXCEL
+app.config['APIS'] = {}
 
 
-def load_file():
-    api.load_file(app.config['BEANCOUNT_FILE'])
+def load_file(beancount_file_slug=None):
+    for filepath in app.config['BEANCOUNT_FILES']:
+        api = BeancountReportAPI()
+        api.load_file(filepath)
+        slug = slugify(api.options['title'])
+        app.config['APIS'][slug] = api
+    app.config['FILE_SLUGS'] = list(app.config['APIS'].keys())
 
 
 def load_settings():
@@ -76,31 +80,36 @@ load_settings()
 discover_help_pages()
 
 
-@app.route('/account/<name>/')
-def account_with_journal(name=None):
-    return render_template('account.html', account_name=name, journal=True)
-
-
-@app.route('/account/<name>/balances/')
-def account_with_interval_balances(name):
-    return render_template('account.html', account_name=name, accumulate=True)
-
-
-@app.route('/account/<name>/changes/')
-def account_with_interval_changes(name):
-    return render_template('account.html', account_name=name, accumulate=False)
-
-
 @app.route('/')
+def root():
+    return redirect(url_for('index', bfile=app.config['FILE_SLUGS'][0]))
+
+
+@app.route('/<bfile>/')
 def index():
     return redirect(url_for('report', report_name='income_statement'))
 
 
-@app.route('/document/', methods=['GET'])
+@app.route('/<bfile>/account/<name>/')
+def account_with_journal(name=None):
+    return render_template('account.html', account_name=name, journal=True)
+
+
+@app.route('/<bfile>/account/<name>/balances/')
+def account_with_interval_balances(name):
+    return render_template('account.html', account_name=name, accumulate=True)
+
+
+@app.route('/<bfile>/account/<name>/changes/')
+def account_with_interval_changes(name):
+    return render_template('account.html', account_name=name, accumulate=False)
+
+
+@app.route('/<bfile>/document/', methods=['GET'])
 def document():
     document_path = request.args.get('file_path', None)
 
-    if document_path and api.is_valid_document(document_path):
+    if document_path and g.api.is_valid_document(document_path):
         # metadata-statement-paths may be relative to the beancount-file
         if not os.path.isabs(document_path):
             document_path = os.path.join(os.path.dirname(
@@ -113,17 +122,17 @@ def document():
         return "File \"{}\" not found in entries.".format(document_path), 404
 
 
-@app.route('/document/add/', methods=['POST'])
+@app.route('/<bfile>/document/add/', methods=['POST'])
 def add_document():
     file = request.files['file']
-    if file and len(api.options['documents']) > 0:
+    if file and len(g.api.options['documents']) > 0:
         # and allowed_file(file.filename):
         # TOOD Probably it should ask to enter a date, if the document
         #      doesn't start with one, so you don't need to rename the
         #      documents in advance.
 
         target_folder_index = int(request.form['targetFolderIndex'])
-        target_folder = api.options['documents'][target_folder_index]
+        target_folder = g.api.options['documents'][target_folder_index]
 
         filename = os.path.join(
             os.path.dirname(app.config['BEANCOUNT_FILE']),
@@ -145,12 +154,12 @@ def add_document():
            "Aborted document upload.", 424
 
 
-@app.route('/context/<ehash>/')
+@app.route('/<bfile>/context/<ehash>/')
 def context(ehash=None):
     return render_template('context.html', ehash=ehash)
 
 
-@app.route('/query/')
+@app.route('/<bfile>/query/')
 def query():
     name = request.args.get('name', 'query_result')
     result_format = request.args.get('result_format', 'html')
@@ -161,7 +170,7 @@ def query():
         return render_template('query.html')
 
     try:
-        types, rows = api.query(query_string, numberify)
+        types, rows = g.api.query(query_string, numberify)
     except Exception as e:
         return render_template('query.html', error=e)
 
@@ -180,8 +189,8 @@ def query():
         return send_file(fd, as_attachment=True, attachment_filename=filename)
 
 
-@app.route('/help/')
-@app.route('/help/<string:page_slug>/')
+@app.route('/<bfile>/help/')
+@app.route('/<bfile>/help/<string:page_slug>/')
 def help_page(page_slug='_index'):
     if page_slug not in app.config['HELP_PAGES'].keys():
         abort(404)
@@ -191,12 +200,12 @@ def help_page(page_slug='_index'):
     return render_template('help.html', help_html=html, page_slug=page_slug)
 
 
-@app.route('/journal/')
+@app.route('/<bfile>/journal/')
 def journal():
     return render_template('journal.html')
 
 
-@app.route('/source/', methods=['GET', 'POST'])
+@app.route('/<bfile>/source/', methods=['GET', 'POST'])
 def source():
     if request.method == "GET":
         if request.is_xhr:
@@ -207,12 +216,12 @@ def source():
                     settings_file_content = f.read()
                 return settings_file_content
             else:
-                return api.source(file_path=requested_file_path)
+                return g.api.source(file_path=requested_file_path)
         else:
             return render_template(
                 'source.html',
                 file_path=request.args.get('file_path',
-                                           api.beancount_file_path))
+                                           g.api.beancount_file_path))
 
     elif request.method == "POST":
         file_path = request.form['file_path']
@@ -225,21 +234,21 @@ def source():
         if file_path == app.config['DEFAULT_SETTINGS']:
             successful = False
         else:
-            successful = api.set_source(file_path=file_path, source=source)
+            successful = g.api.set_source(file_path=file_path, source=source)
         return str(successful)
 
 
-@app.route('/event/<event_type>/')
+@app.route('/<bfile>/event/<event_type>/')
 def event_details(event_type=None):
     return render_template('event_detail.html', event_type=event_type)
 
 
-@app.route('/holdings/by_<aggregation_key>/')
+@app.route('/<bfile>/holdings/by_<aggregation_key>/')
 def holdings_by(aggregation_key):
     return render_template('holdings.html', aggregation_key=aggregation_key)
 
 
-@app.route('/<report_name>/')
+@app.route('/<bfile>/<report_name>/')
 def report(report_name):
     if report_name in [
             'balance_sheet',
@@ -263,7 +272,7 @@ def report(report_name):
 def format_currency(value, currency=None):
     if not value:
         return ''
-    return api.quantize(value, currency)
+    return g.api.quantize(value, currency)
 
 
 @app.template_filter()
@@ -318,10 +327,20 @@ def should_collapse_account(account_name):
 @app.template_filter()
 def uptodate_eligible(account_name):
     key = 'fava-uptodate-indication'
-    if key in api.account_open_metadata(account_name):
-        return api.account_open_metadata(account_name)[key] == 'True'
+    if key in g.api.account_open_metadata(account_name):
+        return g.api.account_open_metadata(account_name)[key] == 'True'
     else:
         return False
+
+
+@app.url_value_preprocessor
+def pull_beancount_file(endpoint, values):
+    g.beancount_file_slug = values.pop('bfile', None)
+    if not g.beancount_file_slug:
+        g.beancount_file_slug = app.config['FILE_SLUGS'][0]
+    if g.beancount_file_slug not in app.config['FILE_SLUGS']:
+        abort(404)
+    g.api = app.config['APIS'][g.beancount_file_slug]
 
 
 @app.context_processor
@@ -346,16 +365,21 @@ def template_context():
 
     return dict(url_for_current=url_for_current,
                 url_for_source=url_for_source,
-                api=api,
-                options=api.options,
-                operating_currencies=api.options['operating_currency'],
+                api=g.api,
+                options=g.api.options,
+                operating_currencies=g.api.options['operating_currency'],
                 today=datetime.now().strftime('%Y-%m-%d'),
                 interval=request.args.get('interval',
-                                          app.config['default-interval']))
+                                          app.config['default-interval']),)
 
 
 @app.url_defaults
 def inject_filters(endpoint, values):
+    if 'bfile' in values or not g.beancount_file_slug:
+        return
+    if app.url_map.is_endpoint_expecting(endpoint, 'bfile'):
+        values['bfile'] = g.beancount_file_slug
+
     if endpoint == 'static':
         return
     for filter in ['time', 'account', 'interval']:
@@ -374,7 +398,7 @@ def inject_filters(endpoint, values):
 
 @app.before_request
 def perform_global_filters():
-    if 'operating_currency' not in api.options:
+    if 'operating_currency' not in g.api.options:
         flash('No operating currency specified. '
               'Please add one to your beancount file.')
 
@@ -387,7 +411,7 @@ def perform_global_filters():
     }
 
     try:
-        api.filter(**g.filters)
+        g.api.filter(**g.filters)
     except FilterException as e:
         g.filters['time'] = None
         flash(str(e))

--- a/fava/docs/features.md
+++ b/fava/docs/features.md
@@ -66,3 +66,8 @@ By default, fava only supports export to `csv` for query results. For support
 of `xls`, `xlsx` and `ods`, install fava with the `excel` feature:
 
     pip3 install fava[excel]
+
+## Multiple Beancount files
+
+When you start fava specifying multiple Beancount files, you can click the
+Beancount file name on the top left to switch between the files.

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -21,6 +21,12 @@ $(document).ready(function() {
     // Global keyboard shortcuts
     keyboardShortcuts.global();
 
+    // File switching
+    $('select#beancount_file').on('change', function(event) {
+        event.preventDefault();
+        window.location = $('select#beancount_file').val();
+    })
+
     // Tree-expanding
     if ($('.tree-table').length) {
         treeTable.initTreeTable();

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -101,6 +101,16 @@ header {
         font-size: 14px;
         font-weight: normal;
 
+        select {
+            border: none;
+            background: transparent;
+            color: white;
+            font-size: 14px;
+            -webkit-appearance: none;
+            cursor: pointer;
+            outline: none;
+        }
+
         strong {
             margin-left: 10px;
 

--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -36,7 +36,14 @@
 <body>
     <header>
         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAMAAABF0y+mAAAAsVBMVEUAAAD///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////+3mHKcAAAAOnRSTlMAAQMEBQYHCAwNDg8QExkaISImJzQ7RUZHSUtVZGtsb3FzdXd4f5WYm56jr7y+xcfP2tze4OLk6/X9+wsXVgAAAMJJREFUKFPFkWkTgiAYhDG1wy677VSzw0q6pKz3//+wBGRkGO2r+4ndZ9hhFoQq0AaXKZoiKFfE4Uzt82iKOWyrcJjDJU90N45dnZ/3HCbrPvfmE64YHkZ216MQi6rwPUBp0VF4GVrQowlAqwA6cN8xKJ4uwyDNGdz+g0EBnAvoFEALxjZC9gIsCd60zJy6ZqpRmFmNLfQ9NJirE7pWbDLTuYj5SI0Fhk+IzwdqfvLhJ0jRSvqVl/rRCYdnKNVG7atcP+gmOQsBuK8NAAAAAElFTkSuQmCC" alt="">
-        <h1 class="site-name">{{ api.title or 'fava' }} <strong>{{ page_title }}</strong></h1>
+        <h1 class="site-name">
+            <select id="beancount_file">
+                {% for file_slug, file_api in config['APIS'].items() %}
+                    <option value="{{ url_for('index', bfile=file_slug) }}"{% if file_slug == g.beancount_file_slug %} selected="selected"{% endif %}>{{ file_api.title or 'fava' }}</option>
+                {% endfor %}
+            </select>
+            <strong>{{ page_title }}</strong>
+        </h1>
         {% if show_filters %}
         <nav>
             {% include "_entry_filters.html" %}

--- a/fava/util/__init__.py
+++ b/fava/util/__init__.py
@@ -1,3 +1,19 @@
+import re
+from unicodedata import normalize
+
+_punct_re = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
+
+
+def slugify(text):
+    """Generates an slightly worse ASCII-only slug."""
+    result = []
+    for word in _punct_re.split(text.lower()):
+        word = normalize('NFKD', word).encode('ascii', 'ignore')
+        if word:
+            result.append(word.decode('ascii'))
+    return str('-'.join(result))
+
+
 def uniquify(seq):
     """Removes duplicate items from a list whilst preserving order. """
     seen = set()

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -5,7 +5,7 @@ from beancount.scripts.example import write_example_file
 from flask import url_for
 import pytest
 
-from fava.application import api, app
+from fava.application import app, load_file
 
 
 @pytest.fixture
@@ -16,15 +16,15 @@ def setup_app(tmpdir):
         write_example_file(datetime.date(1980, 5, 12),
                            datetime.date(today.year - 3, 1, 1),
                            today, True, fd)
-    app.beancount_filename = str(filename)
-    api.load_file(app.beancount_filename)
+    app.config['BEANCOUNT_FILES'] = [str(filename)]
+    load_file()
     app.testing = True
 
 
 class URLQueue:
     def __init__(self):
         self.seen_values = collections.defaultdict(set)
-        self.stack = ['/income_statement/']
+        self.stack = ['/']
         self.seen = set(self.stack)
 
     def append(self, endpoint, values, current):
@@ -64,5 +64,5 @@ def test_scrape(setup_app):
     while urls.stack:
         print(current)
         rv = test_app.get(current)
-        assert rv.status_code == 200
+        assert rv.status_code in [200, 302]
         current = urls.pop()


### PR DESCRIPTION
ref #213 

- `beancount-fava` now accepts multiple filenames
- The title (top left) is now a dropdown where one of the specified
  files can be selected
- The URL for all views is prefixed by a slug generated from the
  filename
- Also update the `test_scrape` function

TODO:

- [ ] Add documentation for this feature, maybe with a screenshot