### PR TITLE
Remove `Equity` charts (#266)

### DIFF
--- a/fava/templates/balance_sheet.html
+++ b/fava/templates/balance_sheet.html
@@ -11,11 +11,9 @@
 
     {{ charts.treemap(api.options['name_assets']) }}
     {{ charts.treemap(api.options['name_liabilities']) }}
-    {{ charts.treemap(api.options['name_equity']) }}
 
     {{ charts.sunburst(api.options['name_assets']) }}
     {{ charts.sunburst(api.options['name_liabilities']) }}
-    {{ charts.sunburst(api.options['name_equity']) }}
 
     <div class="halfleft">
         {% with table_title="Assets", real_accounts=api.closing_balances(api.options['name_assets']), totals=True %}


### PR DESCRIPTION
Since the `Equity` treemap and sunburst charts show only "Opening Balances",
they provide no useful information. Removing them would clean up the chart
picker somewhat (from 15 to 11 for me)