### PR TITLE
Fix bug where multicurrency is enabled but an account only has one

### DIFF
--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -636,8 +636,8 @@ function lineChart() {
 
     function setData(data) {
         x.domain([
-            d3.min(data, function(s) { return s.values[0].date; }),
-            d3.max(data, function(s) { return s.values[s.values.length - 1].date; })
+            d3.min(data, function(s) { return s.values.length ? s.values[0].date : null; }),
+            d3.max(data, function(s) { return s.values.length ? s.values[s.values.length - 1].date : null; })
         ]);
         y.domain([
             Math.min(0, d3.min(data, function(d) { return d3.min(d.values, function(d) { return d.value }); })),


### PR DESCRIPTION
When multiple currencies are defined, we try to render all currencies in the line graphs for an account.  If that account only contains one currency, there are no data points for the other line.