### PR TITLE
Fix documentation links

### DIFF
--- a/fava/docs/_index.md
+++ b/fava/docs/_index.md
@@ -4,10 +4,10 @@ title: Index
 
 Welcome to the help pages for Fava:
 
-- [Beancount Syntax](../beancount_syntax/) - short overview of the syntax.
-- [Budgets](../budgets/) - how to use Fava's budgeting feature.
-- [Fava's Features](../features/) - the features in detail.
-- [Running Fava](../running_fava/) - available command-line options.
+- [Beancount Syntax](beancount_syntax/) - short overview of the syntax.
+- [Budgets](budgets/) - how to use Fava's budgeting feature.
+- [Fava's Features](features/) - the features in detail.
+- [Running Fava](running_fava/) - available command-line options.
 
 If you discover bug in Fava, or have some ideas for improvement, please open a
 [bug report](https://github.com/aumayr/fava/issues).


### PR DESCRIPTION
Seems the links in help were broken in a recent refactoring - this corrects them