### PR TITLE
/jump handler removes param if it's specified once with empty value.

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -428,6 +428,9 @@ def jump():
     url = werkzeug.urls.url_parse(request.referrer)
     qs_dict = url.decode_query()
     for key, values in request.args.lists():
+        if len(values) == 1 and values[0] == "":
+            del qs_dict[key]
+            continue
         qs_dict.setlist(key, values)
 
     redirect_url = url.replace(query=werkzeug.urls.url_encode(qs_dict,

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -15,6 +15,8 @@ import werkzeug.urls
     ('/?foo=bar', '/jump?baz=qux', '/?baz=qux&foo=bar'),
     ('/', '/jump?foo=bar&baz=qux', '/?baz=qux&foo=bar'),
     ('/', '/jump?baz=qux', '/?baz=qux'),
+    ('/?foo=bar', '/jump?foo=', '/'),
+    ('/?foo=bar', '/jump?foo=&foo=', '/?foo=&foo='),
 ])
 def test_jump_handler(app, referer, jump_link, expect):
     """Test /jump handler correctly redirect to the right location.
@@ -26,5 +28,8 @@ def test_jump_handler(app, referer, jump_link, expect):
     result = test_client.get(jump_link,
                              headers=[('Referer', referer)])
     with app.test_request_context():
-        assert (result.headers.get('Location', '') == werkzeug.urls.url_join(
-            flask.url_for('root', _external=True), expect))
+        get_url = result.headers.get('Location', '')
+        expect_url = werkzeug.urls.url_join(
+            flask.url_for('root', _external=True),
+            expect)
+        assert result.status_code == 302 and get_url == expect_url


### PR DESCRIPTION
It's weird if someone specify a value more than once with all empty
value, in that case preserve those param values.