### PR TITLE
Fix missing point on line chart when balance is zero.

### DIFF
--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -381,8 +381,11 @@ class BeancountReportAPI():
 
         return [{
             'date': journal_entry['date'],
-            'balance': journal_entry['balance'],
-        } for journal_entry in journal if 'balance' in journal_entry.keys()]
+            'balance': journal_entry['balance'] if journal_entry['balance']
+            # when there's no holding, the balance would be an empty dict.
+            # Synthesize a zero balance based on the 'change' value
+            else {x: 0 for x in journal_entry['change']}
+        } for journal_entry in journal if 'balance' in journal_entry]
 
     def source_files(self):
         # Make sure the included source files are sorted, behind the main

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,3 +2,9 @@ def test_accounts(example_api):
     assert len(example_api.all_accounts) == 91
     assert len(example_api.all_accounts_leaf_only) == 54
     assert 'Assets' not in example_api.all_accounts_leaf_only
+
+
+def test_linechart_data(example_api):
+    data = example_api.linechart_data('Liabilities:AccountsPayable')
+    assert len(data) == 6
+    assert data[-1]['balance']['USD'] == 0


### PR DESCRIPTION
Beancount will not have balance information when there's no holding in
an account (empty balance dict). This might be for good reason. We can
synthesize a zero balance based on the 'change' field.