### PR TITLE
Bug fix for /jump handler.

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -429,7 +429,10 @@ def jump():
     qs_dict = url.decode_query()
     for key, values in request.args.lists():
         if len(values) == 1 and values[0] == "":
-            del qs_dict[key]
+            try:
+                del qs_dict[key]
+            except KeyError:
+                pass
             continue
         qs_dict.setlist(key, values)
 

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -17,6 +17,7 @@ import werkzeug.urls
     ('/', '/jump?baz=qux', '/?baz=qux'),
     ('/?foo=bar', '/jump?foo=', '/'),
     ('/?foo=bar', '/jump?foo=&foo=', '/?foo=&foo='),
+    ('/', '/jump?foo=', '/'),
 ])
 def test_jump_handler(app, referer, jump_link, expect):
     """Test /jump handler correctly redirect to the right location.


### PR DESCRIPTION
A previous change introduced a bug when /jump handler tries to remove a
parameter from query string that doesn't necessary exist. This change
fixed the bug with proper exception handling and a test case to ensure
that.