### PR TITLE
Add support for resolutions as low as 560px

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -375,7 +375,6 @@ def template_context():
                 url_for_source=url_for_source,
                 api=g.api,
                 operating_currencies=g.api.options['operating_currency'],
-                num_currencies=len(g.api.options['operating_currency']),
                 today=datetime.now().strftime('%Y-%m-%d'),
                 interval=request.args.get('interval',
                                           app.config['interval']),)

--- a/fava/application.py
+++ b/fava/application.py
@@ -375,6 +375,7 @@ def template_context():
                 url_for_source=url_for_source,
                 api=g.api,
                 operating_currencies=g.api.options['operating_currency'],
+                num_currencies=len(g.api.options['operating_currency']),
                 today=datetime.now().strftime('%Y-%m-%d'),
                 interval=request.args.get('interval',
                                           app.config['interval']),)

--- a/fava/static/javascript/main.js
+++ b/fava/static/javascript/main.js
@@ -55,4 +55,11 @@ $(document).ready(() => {
       $('.overlay-wrapper').hide();
     }
   });
+
+  $('#aside_button').click((e) => {
+    e.preventDefault();
+    $("aside").toggleClass("active");
+    $("#aside_button").toggleClass("active");
+    return false;
+  });
 });

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -138,7 +138,7 @@ $header_height: 50px;
 $aside_width: 160px;
 
 body {
-    padding: $header_height 0 0 $aside_width;
+    padding: $header_height 0 0 0;
 }
 
 header {
@@ -218,12 +218,36 @@ header {
     }
 }
 
+#aside_button {
+    position: fixed;
+    top: $header_height;
+    left: 0px;
+    height: 32px;
+    width: 32px;
+    background-color: $color_sidebar_background;
+    border-style: solid;
+    border-color: darken($color_sidebar_background, 16);
+    border-width: 0 1px 1px 0;
+    z-index: 1000;
+    display: block;
+}
+
+#aside_button.active {
+    left: $aside_width;
+}
+
+#aside_button svg {
+    height: 100%;
+    width: 100%;
+}
+
 aside {
     position: fixed;
-    top: 50px;
+    top: $header_height;
     bottom: 0;
     left: 0;
     padding-top: 1em;
+    margin-left: -$aside_width;
     flex-shrink: 0;
     width: $aside_width;
     color: $color_sidebar_text;
@@ -231,6 +255,7 @@ aside {
     background-color: $color_sidebar_background;
     overflow-y: auto;
     @include scrollbar(.5em, darken($color_sidebar_background, 30), transparent);
+    z-index: 1000;
 
     h3 {
         text-transform: uppercase;
@@ -298,6 +323,9 @@ aside {
             }
         }
     }
+}
+aside.active {
+    margin-left: 0;
 }
 
 
@@ -594,3 +622,18 @@ table.queryresults {
         margin-left: 3px;
     }
 }
+
+/* Modifications for ipad */
+@media (min-width: 768px) {
+    body {
+        padding: $header_height 0 0 $aside_width;
+    }
+
+    aside {
+        margin-left: 0;
+    }
+    #aside_button {
+        display: none;
+    }
+}
+

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -167,6 +167,7 @@ header {
         margin: 0;
         font-size: 16px;
         font-weight: normal;
+        overflow: hidden;
 
         strong {
             margin-left: 10px;

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -47,6 +47,16 @@
   }
 }
 
+$transitions: all 0.2s ease-out;
+
+@mixin smooth-transitions {
+    -webkit-transition: $transitions;
+    -moz-transition: $transitions;
+    -ms-transition: $transitions;
+    -o-transition: $transitions;
+    transition: $transitions;
+}
+
 // Globals
 
 * {
@@ -142,6 +152,7 @@ $safe_two_column: $min_width * 2 + $aside_width;
 
 body {
     padding: $header_height 0 0 0;
+    @include smooth-transitions;
 }
 
 header {
@@ -234,6 +245,7 @@ header {
     border-width: 0 1px 1px 0;
     z-index: 1000;
     display: block;
+    @include smooth-transitions;
 }
 
 #aside_button.active {
@@ -260,6 +272,7 @@ aside {
     overflow-y: auto;
     @include scrollbar(.5em, darken($color_sidebar_background, 30), transparent);
     z-index: 1000;
+    @include smooth-transitions;
 
     h3 {
         text-transform: uppercase;

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -59,6 +59,7 @@ body {
     font-weight: 400;
     font-size: 14px;
     height: 100%;
+    min-width: 560px;
     color: $color_text;
     background: $color_background;
 }

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -151,7 +151,7 @@ $aside_width: 160px;
 $safe_two_column: $min_width * 2 + $aside_width;
 
 body {
-    padding: $header_height 0 0 0;
+    padding: $header_height 0 0 $aside_width;
     @include smooth-transitions;
 }
 
@@ -244,7 +244,7 @@ header {
     border-color: darken($color_sidebar_background, 16);
     border-width: 0 1px 1px 0;
     z-index: 9;
-    display: block;
+    display: none;
     @include smooth-transitions;
 }
 
@@ -263,7 +263,7 @@ aside {
     bottom: 0;
     left: 0;
     padding-top: 1em;
-    margin-left: -$aside_width;
+    margin-left: 0;
     flex-shrink: 0;
     width: $aside_width;
     color: $color_sidebar_text;
@@ -465,11 +465,21 @@ kbd {
 
 .halfleft,
 .halfright {
-    width: 100%;
+    width: 50%;
 
     h3 {
         text-align: center;
     }
+}
+
+.halfleft {
+    float: left;
+    padding-right: 10px;
+}
+
+.halfright {
+    float: right;
+    padding-left: 10px;
 }
 
 .left {
@@ -630,35 +640,36 @@ table.queryresults {
     }
 }
 
-/* Modifications for ipad */
-@media (min-width: 768px) {
+/* At resolutions smaller than 768px, hide the aside menu.
+   This means that ipads and larger will show the side menu. */
+@media (max-width: 767px) {
     body {
-        padding: $header_height 0 0 $aside_width;
+        padding: $header_height 0 0 0;
     }
 
     aside {
-        margin-left: 0;
+        margin-left: -$aside_width;
     }
     #aside_button {
-        display: none;
+        display: block;
     }
 }
 
-/* At twice min-width + aside_width, it's safe to make two columns */
-/* If min_width is 560px, $safe_two_column is 1280px */
-@media (min-width: $safe_two_column) {
+/* Between 768px and twice min-width + aside_width, make each table fill the
+   entire screen. If min_width is 560px, $safe_two_column is 1280px. */
+@media (max-width: $safe_two_column - 1) {
     .halfleft,
     .halfright {
-        width: 50%;
+        width: 100%;
     }
 
     .halfleft {
-        float: left;
-        padding-right: 10px;
+        float: none;
+        padding-right: 0;
     }
 
     .halfright {
-        float: right;
-        padding-left: 10px;
+        float: none;
+        padding-left: 0;
     }
 }

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -59,7 +59,6 @@ body {
     font-weight: 400;
     font-size: 14px;
     height: 100%;
-    min-width: 1235px;
     color: $color_text;
     background: $color_background;
 }
@@ -448,21 +447,11 @@ kbd {
 
 .halfleft,
 .halfright {
-    width: 50%;
+    width: 100%;
 
     h3 {
         text-align: center;
     }
-}
-
-.halfleft {
-    float: left;
-    padding-right: 10px;
-}
-
-.halfright {
-    float: right;
-    padding-left: 10px;
 }
 
 .left {
@@ -637,3 +626,19 @@ table.queryresults {
     }
 }
 
+@media (min-width: 1280px) {
+    .halfleft,
+    .halfright {
+        width: 50%;
+    }
+
+    .halfleft {
+        float: left;
+        padding-right: 10px;
+    }
+
+    .halfright {
+        float: right;
+        padding-left: 10px;
+    }
+}

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -53,13 +53,15 @@
     box-sizing: border-box;
 }
 
+$min_width: 560px;
+
 html,
 body {
     font-family: $font_family;
     font-weight: 400;
     font-size: 14px;
     height: 100%;
-    min-width: 560px;
+    min-width: $min_width;
     color: $color_text;
     background: $color_background;
 }
@@ -136,6 +138,7 @@ a {
 // Structural and generic elements
 $header_height: 50px;
 $aside_width: 160px;
+$safe_two_column: $min_width * 2 + $aside_width;
 
 body {
     padding: $header_height 0 0 0;
@@ -627,7 +630,9 @@ table.queryresults {
     }
 }
 
-@media (min-width: 1280px) {
+/* At twice min-width + aside_width, it's safe to make two columns */
+/* If min_width is 560px, $safe_two_column is 1280px */
+@media (min-width: $safe_two_column) {
     .halfleft,
     .halfright {
         width: 50%;

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -165,7 +165,7 @@ header {
     color: $color_header_text;
     padding: 0 10px;
     height: $header_height;
-    z-index: 2;
+    z-index: 10;
     display: flex;
     align-items: center;
 
@@ -243,7 +243,7 @@ header {
     border-style: solid;
     border-color: darken($color_sidebar_background, 16);
     border-width: 0 1px 1px 0;
-    z-index: 1000;
+    z-index: 9;
     display: block;
     @include smooth-transitions;
 }
@@ -271,7 +271,7 @@ aside {
     background-color: $color_sidebar_background;
     overflow-y: auto;
     @include scrollbar(.5em, darken($color_sidebar_background, 30), transparent);
-    z-index: 1000;
+    z-index: 9;
     @include smooth-transitions;
 
     h3 {

--- a/fava/static/sass/_editor.scss
+++ b/fava/static/sass/_editor.scss
@@ -18,7 +18,7 @@ article#page-source {
 
     div.editor {
         position: fixed;
-        left: $aside_width;
+        left: 0;
         top: $header_height + 40px;
         right: 0;
         bottom: 0;
@@ -99,4 +99,13 @@ div.editor-wrapper {
     &.ace_autocomplete .ace_content {
         font: 13px $font_family_editor;
     }
+}
+
+/* Modifications for ipad */
+@media (min-width: 768px) {
+article#page-source {
+    div.editor {
+        left: $aside_width;
+    }
+}
 }

--- a/fava/static/sass/_tree-table.scss
+++ b/fava/static/sass/_tree-table.scss
@@ -136,3 +136,21 @@ ol.tree-table {
         &.budget-zero     { color: $color_budget_zero; }
     }
 }
+
+@for $i from 1 through 5 {
+    $num_fraction: 1rem * (1-(($i - 1)/10));
+    ol.tree-table.currencies#{$i} {
+       p > span {
+            &.num-header,
+            &.num {
+                width: 20rem / ($i+1);
+                font-size: $num_fraction;
+            }
+            &.other-header,
+            &.other {
+                width: 20rem / ($i+1) + 3rem;
+                font-size: $num_fraction;
+            }
+       }
+    }
+}

--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -25,6 +25,7 @@
 <!doctype html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='gen/theme_' + config['theme'] + '.css') }}">
     <title>{{ short_title }} - {{ api.title }}</title>
@@ -53,6 +54,9 @@
         </nav>
         {% endif %}
     </header>
+    <a href="#" id="aside_button">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" enable-background="new 0 0 24 24" id="Layer_1" version="1.0" viewBox="0 0 24 24" xml:space="preserve"><circle cx="12" cy="12" r="2"/><circle cx="12" cy="5" r="2"/><circle cx="12" cy="19" r="2"/></svg>
+    </a>
     <aside>
         {% if api.sidebar_links %}
             <h3>{{ _('Custom Links') }}</h3>

--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -55,7 +55,7 @@
         {% endif %}
     </header>
     <a href="#" id="aside_button">
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" enable-background="new 0 0 24 24" id="Layer_1" version="1.0" viewBox="0 0 24 24" xml:space="preserve"><circle cx="12" cy="12" r="2"/><circle cx="12" cy="5" r="2"/><circle cx="12" cy="19" r="2"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="32px" width="32px" enable-background="new 0 0 24 24" id="Layer_1" version="1.0" viewBox="0 0 24 24" xml:space="preserve"><circle cx="12" cy="12" r="2"/><circle cx="12" cy="5" r="2"/><circle cx="12" cy="19" r="2"/></svg>
     </a>
     <aside>
         {% if api.sidebar_links %}

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -5,7 +5,7 @@
 
 {% set show_other_column = (operating_currencies|sort != api.options['commodities']|list|sort) %}
 
-<ol class="tree-table currencies{{ num_currencies }}">
+<ol class="tree-table currencies{{ operating_currencies|length }}">
     <li class="head">
         <p>
         <span class="account"><span>{{ _('Account') }}</span><a href="" class="expand-all hidden" title="{{ _('Expand all accounts') }}">{{ _('Expand all') }}</a></span>

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -5,7 +5,7 @@
 
 {% set show_other_column = (operating_currencies|sort != api.options['commodities']|list|sort) %}
 
-<ol class="tree-table">
+<ol class="tree-table currencies{{ num_currencies }}">
     <li class="head">
         <p>
         <span class="account"><span>{{ _('Account') }}</span><a href="" class="expand-all hidden" title="{{ _('Expand all accounts') }}">{{ _('Expand all') }}</a></span>


### PR DESCRIPTION
I couldn't get much lower than that because multiple currency income/balance tables (where you have 2+ operating currencies) get too squishy to read.

The original layout should look about the same at the original min-width but it should look way better on all pages at smaller resolutions.

This is my first pass after an afternoon of fiddling.  I'm sure I'll come up with better improvements in the future.