### PR TITLE
Fix an issue that zero balance may not show on chart.

### DIFF
--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -386,10 +386,12 @@ class BeancountReportAPI():
 
         return [{
             'date': journal_entry['date'],
-            'balance': journal_entry['balance'] if journal_entry['balance']
-            # when there's no holding, the balance would be an empty dict.
-            # Synthesize a zero balance based on the 'change' value
-            else {x: 0 for x in journal_entry['change']}
+            # when there's no holding for a commodity, it will be missing from
+            # 'balance' field but appear in 'change' field. Use 0 for those
+            # commodities.
+            'balance': {x: journal_entry['balance'].get(x, 0) for x in
+                        journal_entry['change'].keys() |
+                        journal_entry['balance'].keys()}
         } for journal_entry in journal if 'balance' in journal_entry]
 
     def source_files(self):

--- a/tests/example.beancount
+++ b/tests/example.beancount
@@ -5796,6 +5796,18 @@ option "operating_currency" "USD"
 2016-05-06 price VHT                               108.25 USD
 2016-05-06 price GLD                               107.36 USD
 
+2000-01-01 open Assets:Testing:MultipleCommodities
+2000-01-01 *
+  Assets:Testing:MultipleCommodities                  100 USD
+  Equity:Opening-Balances
+
+2000-01-02 *
+  Assets:Testing:MultipleCommodities                    1 XYZ {50 USD}
+  Assets:Testing:MultipleCommodities                  -50 USD
+
+2000-01-03 *
+  Assets:Testing:MultipleCommodities                    1 ABC {50 USD}
+  Assets:Testing:MultipleCommodities                  -50 USD
 
 
 * Cash

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,10 @@
 def test_accounts(example_api):
-    assert len(example_api.all_accounts) == 91
-    assert len(example_api.all_accounts_active) == 60
+    assert len(example_api.all_accounts) == 93
+    assert len(example_api.all_accounts_active) == 61
     assert 'Assets' not in example_api.all_accounts_active
 
 
 def test_linechart_data(example_api):
-    data = example_api.linechart_data('Liabilities:AccountsPayable')
-    assert len(data) == 6
-    assert data[-1]['balance']['USD'] == 0
+    data = example_api.linechart_data('Assets:Testing:MultipleCommodities')
+    assert data[1]['balance'].get('USD', None) == 50
+    assert data[2]['balance'].get('USD', None) == 0

--- a/tests/test_api_filters.py
+++ b/tests/test_api_filters.py
@@ -21,7 +21,7 @@ def test_account_filter(example_api):
     account_filter.set('Assets')
     filtered_entries = account_filter.apply(
         example_api.all_entries, example_api.options)
-    assert len(filtered_entries) == 537
+    assert len(filtered_entries) == 541
     assert all(map(
         lambda x: hasattr(x, 'account') and
         account.has_component(x.account, 'Assets') or any(map(
@@ -42,7 +42,7 @@ def test_time_filter(example_api):
     assert time_filter.end_date == datetime.date(2018, 1, 1)
     filtered_entries = time_filter.apply(
         example_api.all_entries, example_api.options)
-    assert len(filtered_entries) == 81
+    assert len(filtered_entries) == 83
 
     time_filter.set('1000')
     filtered_entries = time_filter.apply(


### PR DESCRIPTION
When one of the commodities an account holds goes to zero, it will not
show in `balance` field in the corresponding entry. A previous attempt
to workaround the issue didn't consider when an account holds more than
two commodities. This change fixed the workaround. Test case has been
updated to cover it.