### PR TITLE
Fix highlighting of tags

### DIFF
--- a/fava/static/javascript/codemirror-mode-beancount.js
+++ b/fava/static/javascript/codemirror-mode-beancount.js
@@ -38,7 +38,11 @@ CodeMirror.defineSimpleMode('beancount', {
       token: 'whitespace',
     },
     {
-      regex: /[*!&?%PSTCURM]|txn/,
+      regex: /#[A-Za-z0-9\-_\/.]+/,
+      token: 'tag',
+    },
+    {
+      regex: /[*!&#?%PSTCURM]|txn/,
       token: 'directive transaction',
     },
     // other dated directives
@@ -71,10 +75,6 @@ CodeMirror.defineSimpleMode('beancount', {
     {
       regex: /(?:[0-9]+|[0-9][0-9,]+[0-9])(?:\.[0-9]*)?/,
       token: 'number',
-    },
-    {
-      regex: /#[A-Za-z0-9\-_\/.]+/,
-      token: 'tag',
     },
     {
       regex: /\^[A-Za-z0-9\-_\/.]+/,

--- a/fava/static/javascript/codemirror-mode-beancount.js
+++ b/fava/static/javascript/codemirror-mode-beancount.js
@@ -38,7 +38,7 @@ CodeMirror.defineSimpleMode('beancount', {
       token: 'whitespace',
     },
     {
-      regex: /[*!&#?%PSTCURM]|txn/,
+      regex: /[*!&?%PSTCURM]|txn/,
       token: 'directive transaction',
     },
     // other dated directives


### PR DESCRIPTION
The `beancount`-mode for codemirror does not match tags correctly, like this example:

```sql
2016-09-15 * "" "Test" #tag1
    Expenses:Test 10.00 USD
    Assets:Test 10.00 USD
```
