### PR TITLE
JS api: move things for consistency; basic csrf protection

### DIFF
--- a/fava/static/javascript/documents-upload.js
+++ b/fava/static/javascript/documents-upload.js
@@ -10,9 +10,7 @@ module.exports.initDocumentsUpload = function initDocumentsUpload() {
       url: window.documentsUploadUrl,
       data: formData,
       contentType: false,
-      cache: false,
       processData: false,
-      async: false,
       success(data) {
         alert(data);
       },
@@ -41,7 +39,6 @@ module.exports.initDocumentsUpload = function initDocumentsUpload() {
 
         for (let i = 0; i < files.length; i++) {
           const formData = new FormData();
-          console.log(files[i]);
           formData.append('file', files[i]);
           formData.append('account_name', $(this).attr('data-account-name'));
 

--- a/fava/static/javascript/editor.js
+++ b/fava/static/javascript/editor.js
@@ -52,7 +52,7 @@ function saveEditorContent(cm) {
     source: cm.getValue(),
   })
     .done((data) => {
-      if (data !== 'True') {
+      if (!data.success) {
         alert(`Writing to\n\n\t${fileName}\n\nwas not successful.`);
       } else {
         $button
@@ -72,8 +72,8 @@ function formatEditorContent(cm) {
     source: cm.getValue(),
   })
     .done((data) => {
-      if (data !== 'False') {
-        cm.setValue(data);
+      if (data.success) {
+        cm.setValue(data.payload);
         cm.scrollTo(null, scrollPosition);
       } else {
         alert('There was an error formatting the file ${fileName} with bean-format.');

--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -117,7 +117,7 @@
 
         // documents upload
         window.documentsFolders = {{ api.options['documents']|tojson|safe }};
-        window.documentsUploadUrl = "{{ url_for('add_document') }}";
+        window.documentsUploadUrl = "{{ url_for('api_add_document') }}";
 
         // editor
         window.allAccounts = {{ api.all_accounts_active|tojson|safe }};

--- a/fava/templates/overlays/_documents_upload.html
+++ b/fava/templates/overlays/_documents_upload.html
@@ -2,7 +2,7 @@
     <div class="overlay">
         <a href="#" class="close-overlay">(close)</a>
         <h2>Document upload</h2>
-        <form action="{{ url_for('add_document') }}" method="POST">
+        <form action="{{ url_for('api_add_document') }}" method="POST">
             <label for="document-name" id="label-document-name">Document name:</label>
             <input type="text" name="document-name" id="document-name">
             <label for="documents-upload-folder" id="label-documents-upload-folder">Document upload base folder:</label>

--- a/fava/templates/query.html
+++ b/fava/templates/query.html
@@ -85,10 +85,10 @@
         <div class="queryresults-wrapper">
             <p class="download">
                 {{ _('Download as') }}
-                <a class="download-csv" href="{{ url_for('query', query_string=query, name=name, result_format='csv') }}">CSV</a>{% if config['HAVE_EXCEL'] %},
-                <a class="download-csv" href="{{ url_for('query', query_string=query, name=name, result_format='xls') }}">XLS</a>,
-                <a class="download-csv" href="{{ url_for('query', query_string=query, name=name, result_format='xlsx') }}">XLSX</a> or
-                <a class="download-csv" href="{{ url_for('query', query_string=query, name=name, result_format='ods') }}">ODS</a>
+                <a class="download-csv" href="{{ url_for('download_query', query_string=query, name=name, result_format='csv') }}">CSV</a>{% if config['HAVE_EXCEL'] %},
+                <a class="download-csv" href="{{ url_for('download_query', query_string=query, name=name, result_format='xls') }}">XLS</a>,
+                <a class="download-csv" href="{{ url_for('download_query', query_string=query, name=name, result_format='xlsx') }}">XLSX</a> or
+                <a class="download-csv" href="{{ url_for('download_query', query_string=query, name=name, result_format='ods') }}">ODS</a>
             {% endif %}
             </p>
             <h3>{{ _('Result') }}</h3>

--- a/fava/templates/source.html
+++ b/fava/templates/source.html
@@ -2,6 +2,7 @@
 {% set active_page = 'source' %}
 {% set show_filters = False %}
 {% set source_files = api.source_files() %}
+{% set file_path = request.args.get('file_path', api.beancount_file_path) %}
 
 {% block content %}
     {% if config['use-external-editor'] %}
@@ -28,14 +29,14 @@
         {% endfor %}
         </div>
     {% else %}
-    <form action="{{ url_for('source') }}" method="POST">
+    <form action="{{ url_for('api_source') }}" method="POST">
         <select id="source-editor-select" name="file_path">
             {% for source_file in source_files %}
                 <option{% if source_file == file_path %} selected="selected"{% endif %}>{{ source_file }}</option>
             {% endfor %}
         </select>
         <input id="source-editor-submit" type="submit" value="{{ _('Save') }}">
-        <input id="source-editor-format" type="submit" data-url="{{ url_for('source_format') }}" value="{{ _('Format') }}">
+        <input id="source-editor-format" type="submit" data-url="{{ url_for('api_format_source') }}" value="{{ _('Format') }}">
         <div id="source-editor-wrapper" class="source-editor-wrapper">
             <textarea id="source-editor" name="source" autofocus>{{ api.source(file_path) or '' }}</textarea>
         </div>

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -11,12 +11,12 @@ class URLQueue:
         self.app = app
 
     def append(self, endpoint, values, current):
-        if (endpoint in ['source', 'source_format', 'document', 'add_document'] or  # noqa
-                'REPLACEME' in values.values()):
-            return
         real_endpoint = endpoint
         if 'report_name' in values:
             endpoint = values['report_name']
+        if endpoint in ['document', 'source'] or endpoint.startswith('api_') \
+                or 'REPLACEME' in values.values():
+            return
         filters = ['account', 'interval', 'payee', 'tag', 'time']
         value_keys = frozenset([key for key, value in values.items()
                                 if value and key not in filters])


### PR DESCRIPTION
Checking for the `XMLHttpRequest` in the header should safeguard us against all CSRF attacks possible in Javascript. An attack using flash might still be possible, against which we could check the origin in the request header. However this would complicates setting up fava behind a reverse proxy... Ref #347

@aumayr - a side note: Could you add documentation for documents upload? It's currently a completely hidden feature.