### PR TITLE
Rename $i-currencies to currencies-$i to fix responsive design

### DIFF
--- a/fava/static/sass/_tree-table.scss
+++ b/fava/static/sass/_tree-table.scss
@@ -135,7 +135,7 @@
 @for $i from 1 through 5 {
   $num-fraction: 1rem * (1 - (($i - 1)/10));
 
-  .#{$i}-currencies {
+  .currencies-#{$i} {
     p > span {
       &.num {
         font-size: $num-fraction;

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -2,7 +2,7 @@
 {% set show_other_column = (operating_currencies|sort != api.options['commodities']|list|sort) %}
 
 {% macro tree(real_account, totals=True) %}
-<ol class="tree-table {{ operating_currencies|length }}-currencies">
+<ol class="tree-table currencies-{{ operating_currencies|length }}">
     <li class="head">
         <p>
         <span class="account-cell"><span>{{ _('Account') }}</span><a href="#" class="expand-all hidden" title="{{ _('Expand all accounts') }}">{{ _('Expand all') }}</a></span>


### PR DESCRIPTION
I'm not sure what changed, but $i-currencies is no longer valid?

Seems to fix https://github.com/aumayr/fava/issues/380, not sure exactly what changed.